### PR TITLE
JBPM-5542: Stunner - Properties Panel and Process Explorer are shown for incorrect asset

### DIFF
--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/UberfireDocksImpl.java
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/UberfireDocksImpl.java
@@ -78,12 +78,12 @@ public class UberfireDocksImpl implements UberfireDocks {
                                         uberfireDocks);
             }
         }
-        updateDocks();
+        updateDocks(docks);
     }
 
     public void perspectiveChangeEvent(@Observes PerspectiveChange perspectiveChange) {
         this.currentSelectedPerspective = perspectiveChange.getIdentifier();
-        updateDocks();
+        updateAllDocks();
         fireDockReadyEvent();
     }
 
@@ -101,7 +101,7 @@ public class UberfireDocksImpl implements UberfireDocks {
                                         uberfireDocks);
             }
         }
-        updateDocks();
+        updateDocks(docks);
     }
 
     @Override
@@ -150,17 +150,27 @@ public class UberfireDocksImpl implements UberfireDocks {
         }
     }
 
-    private void updateDocks() {
+    private void updateDocks(UberfireDock... docks) {
         if (docksBars.isReady()) {
-            docksBars.clearAndCollapseAllDocks();
-            if (currentSelectedPerspective != null) {
-                List<UberfireDock> docks = docksPerPerspective.get(currentSelectedPerspective);
-                if (docks != null && !docks.isEmpty()) {
-                    for (UberfireDock dock : docks) {
-                        docksBars.addDock(dock);
+            if (docks != null) {
+                List<UberfireDockPosition> processedPositions = new ArrayList<>();
+                for (UberfireDock dock : docks) {
+                    if (!processedPositions.contains(dock.getDockPosition())) {
+                        processedPositions.add(dock.getDockPosition());
+                        docksBars.clearAndCollapse(dock.getDockPosition());
                     }
-                    expandAllAvailableDocks();
                 }
+            }
+        }
+    }
+
+    private void updateAllDocks() {
+        docksBars.clearAndCollapseAllDocks();
+        if (currentSelectedPerspective != null) {
+            List<UberfireDock> activeDocks = docksPerPerspective.get(currentSelectedPerspective);
+            if (activeDocks != null && !activeDocks.isEmpty()) {
+                activeDocks.forEach(activeDock -> docksBars.addDock(activeDock));
+                expandAllAvailableDocks();
             }
         }
     }

--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/DocksBars.java
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/DocksBars.java
@@ -152,21 +152,30 @@ public class DocksBars {
         return max;
     }
 
+    public void clearAndCollapseDocks(final UberfireDockPosition position) {
+        collapsePosition(position);
+        clearPosition(position);
+    }
+
     public void clearAndCollapseAllDocks() {
-        collapseAll();
-        clearAll();
+        clearAndCollapseDocks(null);
     }
 
-    private void clearAll() {
-        for (DocksBar docksBar : getDocksBars()) {
-            docksBar.clearAll();
-        }
+    private void clearPosition(final UberfireDockPosition position) {
+        getDocksBars().forEach(docksBar -> {
+            if (position == null || docksBar.getPosition().equals(position)) {
+                docksBar.clearAll();
+            }
+        });
     }
 
-    private void collapseAll() {
-        for (DocksBar docksBar : getDocksBars()) {
-            collapse(docksBar);
-        }
+    private void collapsePosition(final UberfireDockPosition position) {
+        getDocksBars().forEach(docksBar -> {
+            // if position is null or equals the docksBar we must collapse the docksBar
+            if (position == null || docksBar.getPosition().equals(position)) {
+                collapse(docksBar);
+            }
+        });
     }
 
     private void collapse(DocksBar docksBar) {

--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/UberfireDocksImplTest.java
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/UberfireDocksImplTest.java
@@ -140,8 +140,7 @@ public class UberfireDocksImplTest {
 
         assertEquals(SOME_PERSPECTIVE,
                      uberfireDocks.currentSelectedPerspective);
-        verify(this.docksBars,
-               times(2)).clearAndCollapseAllDocks();
+        verify(this.docksBars).clearAndCollapseAllDocks();
         verify(this.docksBars).addDock(dock0);
         verify(this.docksBars).addDock(dock1);
 
@@ -159,11 +158,11 @@ public class UberfireDocksImplTest {
         uberfireDocks.currentSelectedPerspective = SOME_PERSPECTIVE;
 
         uberfireDocks.remove(dock0);
-        verify(docksBars).clearAndCollapseAllDocks();
+        verify(docksBars).clearAndCollapse(dock0.getDockPosition());
 
         verify(docksBars,
                never()).addDock(dock0);
-        verify(docksBars).addDock(dock1);
+        verify(docksBars, never()).addDock(dock1);
     }
 
     @Test


### PR DESCRIPTION
The idea is refreshing only the affected docks when new dock elements are added or removed.

@ederign can you take a look? Does it fit what we talked yesterday?