### PR TITLE
PLANNER-753: Workbench: Score type selector is not fully visible in planner data object editor

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/pmgr/nswe/part/WorkbenchPartView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/pmgr/nswe/part/WorkbenchPartView.java
@@ -17,6 +17,7 @@ package org.uberfire.client.workbench.pmgr.nswe.part;
 
 import javax.enterprise.context.Dependent;
 
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.ScrollPanel;
 import com.google.gwt.user.client.ui.SimpleLayoutPanel;
@@ -36,6 +37,10 @@ public class WorkbenchPartView
 
     public WorkbenchPartView() {
         setWidget(sp);
+
+        // Make sure the panel gets enough vertical space when available
+        sp.getElement().getStyle().setHeight(100,
+                                             Style.Unit.PCT);
 
         // ScrollPanel creates an additional internal div that we need to style
         sp.getElement().getFirstChildElement().setClassName("uf-scroll-panel");

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/pmgr/unanchored/part/UnanchoredWorkbenchPartView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/pmgr/unanchored/part/UnanchoredWorkbenchPartView.java
@@ -18,6 +18,7 @@ package org.uberfire.client.workbench.pmgr.unanchored.part;
 
 import javax.enterprise.context.Dependent;
 
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.ScrollPanel;
@@ -38,6 +39,10 @@ public class UnanchoredWorkbenchPartView
 
     public UnanchoredWorkbenchPartView() {
         setWidget(sp);
+
+        // Make sure the panel gets enough vertical space when available
+        sp.getElement().getStyle().setHeight(100,
+                                             Style.Unit.PCT);
 
         // ScrollPanel creates an additional internal div that we need to style
         sp.getElement().getFirstChildElement().setClassName("uf-scroll-panel");


### PR DESCRIPTION
Fixes an issue where select content gets clipped in a dock, even if there's enough space to hold it.

@ederign Can you please have a look? Thanks in advance!