### PR TITLE
Upgraded Asset editor can broke navigation in Business Central

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityBeansCache.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityBeansCache.java
@@ -187,6 +187,9 @@ public class ActivityBeansCache {
 
         validateUniqueness(id);
 
+        activitiesById.put(id,
+                           activityBean);
+
         resourceActivities.add(new ActivityAndMetaInfo(activityBean,
                                                        Integer.valueOf(priority),
                                                        Arrays.asList(resourceTypeName)));
@@ -201,6 +204,10 @@ public class ActivityBeansCache {
         activitiesById.put(id,
                            activityBean);
         splashActivities.add((SplashScreenActivity) activityBean.getInstance());
+    }
+
+    public boolean hasActivity(String id){
+        return activitiesById.containsKey(id);
     }
 
     /**

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityBeansCacheTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityBeansCacheTest.java
@@ -151,14 +151,32 @@ public class ActivityBeansCacheTest {
         String higherPriority = "20000";
         String lowerPriority = "1";
 
-        cache.addNewEditorActivity(mock(SyncBeanDef.class),
+        SyncBeanDef mock = mock(SyncBeanDef.class);
+        when(mock.getName()).thenReturn("resource1");
+        cache.addNewEditorActivity(mock,
                                    lowerPriority,
                                    "resource");
-        cache.addNewEditorActivity(mock(SyncBeanDef.class),
+        SyncBeanDef mock1 = mock(SyncBeanDef.class);
+        when(mock1.getName()).thenReturn("resource2");
+        cache.addNewEditorActivity(mock1,
                                    higherPriority,
-                                   "resource");
+                                   "resource1");
         List<ActivityBeansCache.ActivityAndMetaInfo> resourceActivities = cache.getResourceActivities();
 
-        assertEquals(resourceActivities.get(0).getPriority(), Integer.valueOf(higherPriority).intValue());
+        assertEquals(resourceActivities.get(0).getPriority(),
+                     Integer.valueOf(higherPriority).intValue());
+    }
+
+    @Test
+    public void addEditorActivityShouldAddToActivitiesByID() {
+        String resource = "resource";
+
+        SyncBeanDef mock = mock(SyncBeanDef.class);
+        when(mock.getName()).thenReturn(resource);
+        cache.addNewEditorActivity(mock,
+                                   "1",
+                                   resource);
+
+        assertTrue(cache.hasActivity(resource));
     }
 }


### PR DESCRIPTION
Could you please guys take a look? @hasys ? :)

This is an issue found by @hasys during QE of https://issues.jboss.org/browse/RHBPMS-4615.

Basically, what is going on is:

When a perspective is not transient, Uberfire stores its state on VFS and try to reload it.

The issue happens when I try to restore a state of a Place Request that doesn't exist anymore (Editors and Screens).

With this PR, if the state stored is invalid (null or references a Place Request that doesn't exist anymore) it's loads the default perspective definition.

When approved, this will be ported for 0.9.x and 1.0.x



