### PR TITLE
[0.9.x] RHBPMS-4706: [GSS](6.4.z) Embedded Authoring perspective is broken when using parameter controlled URL

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarPresenter.java
@@ -19,10 +19,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
@@ -58,296 +54,293 @@ import org.uberfire.workbench.model.menu.impl.BaseMenuVisitor;
  * specific to GWT. An alternative implementation should be considered for use
  * within Eclipse.
  */
-@ApplicationScoped
 public class WorkbenchMenuBarPresenter implements WorkbenchMenuBar {
 
+    protected AuthorizationManager authzManager;
+    protected User identity;
     private boolean useExpandedMode = true;
     private boolean expanded = true;
-
     private List<Menus> addedMenus;
-
-    @Inject
-    protected AuthorizationManager authzManager;
-
-    @Inject
-    protected User identity;
-
-    @Inject
     private PerspectiveManager perspectiveManager;
-
-    @Inject
     private ActivityManager activityManager;
+    private View view;
 
-    public interface View extends IsWidget {
+    WorkbenchMenuBarPresenter(final AuthorizationManager authzManager,
+                              final PerspectiveManager perspectiveManager,
+                              final ActivityManager activityManager,
+                              final User identity,
+                              final View view) {
+        this.authzManager = authzManager;
+        this.perspectiveManager = perspectiveManager;
+        this.activityManager = activityManager;
+        this.identity = identity;
+        this.view = view;
 
-        void clear();
-
-        void addMenuItem( String id,
-                          String label,
-                          String parentId,
-                          Command command,
-                          MenuPosition position );
-
-        void addCustomMenuItem( Widget menu,
-                                MenuPosition position );
-
-        void addGroupMenuItem( String id,
-                               String label,
-                               MenuPosition position );
-
-        void selectMenuItem( String id );
-
-        void addContextMenuItem( String menuItemId,
-                                 String id,
-                                 String label,
-                                 String parentId,
-                                 Command command,
-                                 MenuPosition position );
-
-        void addContextGroupMenuItem( String menuItemId,
-                                      String id,
-                                      String label,
-                                      MenuPosition position );
-
-        void clearContextMenu();
-
-        void expand();
-
-        void collapse();
-
-        void addCollapseHandler( Command command );
-
-        void addExpandHandler( Command command );
-
-        void enableMenuItem( String menuItemId,
-                             boolean enabled );
-
-        void enableContextMenuItem( String menuItemId,
-                                    boolean enabled );
-
+        setup();
     }
 
-    @Inject
-    private View view;
+    protected void setup() {
+        view.addExpandHandler(new Command() {
+            @Override
+            public void execute() {
+                expanded = true;
+            }
+        });
+        view.addCollapseHandler(new Command() {
+            @Override
+            public void execute() {
+                expanded = false;
+            }
+        });
+    }
 
     public IsWidget getView() {
         return this.view;
     }
 
-    @PostConstruct
-    protected void setup() {
-        view.addExpandHandler( new Command() {
-            @Override
-            public void execute() {
-                expanded = true;
-            }
-        } );
-        view.addCollapseHandler( new Command() {
-            @Override
-            public void execute() {
-                expanded = false;
-            }
-        } );
-    }
-
     @Override
-    public void addMenus( final Menus menus ) {
-        if ( menus != null && !menus.getItems().isEmpty() ) {
+    public void addMenus(final Menus menus) {
+        if (menus != null && !menus.getItems().isEmpty()) {
 
-            if ( addedMenus == null ) {
+            if (addedMenus == null) {
                 addedMenus = new ArrayList<Menus>();
             }
 
-            addedMenus.add( menus );
+            addedMenus.add(menus);
 
-            if ( menusMustBeReordered( menus ) ) {
+            if (menusMustBeReordered(menus)) {
                 reorderMenus();
                 view.clear();
 
-                for ( Menus currentMenus : addedMenus ) {
-                    visitMenus( currentMenus );
+                for (Menus currentMenus : addedMenus) {
+                    visitMenus(currentMenus);
                 }
             } else {
-                visitMenus( menus );
+                visitMenus(menus);
             }
         }
     }
 
-    private boolean menusMustBeReordered( final Menus menus ) {
-        if ( addedMenus.size() < 2 ) {
+    private boolean menusMustBeReordered(final Menus menus) {
+        if (addedMenus.size() < 2) {
             return false;
         }
 
-        final Menus previousMenus = addedMenus.get( addedMenus.size() - 2 );
+        final Menus previousMenus = addedMenus.get(addedMenus.size() - 2);
         return previousMenus.getOrder() > menus.getOrder();
     }
 
     private void reorderMenus() {
-        Collections.sort( addedMenus, new Comparator<Menus>() {
-            @Override
-            public int compare( final Menus o1,
-                                final Menus o2 ) {
-                return o1.getOrder() - o2.getOrder();
-            }
-        } );
+        Collections.sort(addedMenus,
+                         new Comparator<Menus>() {
+                             @Override
+                             public int compare(final Menus o1,
+                                                final Menus o2) {
+                                 return o1.getOrder() - o2.getOrder();
+                             }
+                         });
     }
 
-    private void visitMenus( final Menus addedMenu ) {
-        addedMenu.accept( new AuthFilterMenuVisitor( authzManager, identity, new BaseMenuVisitor() {
+    private void visitMenus(final Menus addedMenu) {
+        addedMenu.accept(new AuthFilterMenuVisitor(authzManager,
+                                                   identity,
+                                                   new BaseMenuVisitor() {
 
-            private String parentId = null;
+                                                       private String parentId = null;
 
-            @Override
-            public boolean visitEnter( final MenuGroup menuGroup ) {
-                parentId = getMenuItemId( menuGroup );
-                view.addGroupMenuItem( parentId, menuGroup.getCaption(), menuGroup.getPosition() );
-                return true;
-            }
+                                                       @Override
+                                                       public boolean visitEnter(final MenuGroup menuGroup) {
+                                                           parentId = getMenuItemId(menuGroup);
+                                                           view.addGroupMenuItem(parentId,
+                                                                                 menuGroup.getCaption(),
+                                                                                 menuGroup.getPosition());
+                                                           return true;
+                                                       }
 
-            @Override
-            public void visitLeave( MenuGroup menuGroup ) {
-                parentId = null;
-            }
+                                                       @Override
+                                                       public void visitLeave(MenuGroup menuGroup) {
+                                                           parentId = null;
+                                                       }
 
-            @Override
-            public void visit( final MenuItemPlain menuItemPlain ) {
-                view.addMenuItem( getMenuItemId( menuItemPlain ), menuItemPlain.getCaption(), parentId, null, menuItemPlain.getPosition() );
-                setupEnableDisableMenuItem( menuItemPlain );
-            }
+                                                       @Override
+                                                       public void visit(final MenuItemPlain menuItemPlain) {
+                                                           view.addMenuItem(getMenuItemId(menuItemPlain),
+                                                                            menuItemPlain.getCaption(),
+                                                                            parentId,
+                                                                            null,
+                                                                            menuItemPlain.getPosition());
+                                                           setupEnableDisableMenuItem(menuItemPlain);
+                                                       }
 
-            @Override
-            public void visit( final MenuCustom<?> menuCustom ) {
-                final Object build = menuCustom.build();
-                if ( build instanceof IsWidget ) {
-                    view.addCustomMenuItem( ( (IsWidget) build ).asWidget(), menuCustom.getPosition() );
-                } else {
-                    view.addMenuItem( getMenuItemId( menuCustom ), menuCustom.getCaption(), parentId, null, menuCustom.getPosition() );
-                }
-                setupEnableDisableMenuItem( menuCustom );
-            }
+                                                       @Override
+                                                       public void visit(final MenuCustom<?> menuCustom) {
+                                                           final Object build = menuCustom.build();
+                                                           if (build instanceof IsWidget) {
+                                                               view.addCustomMenuItem(((IsWidget) build).asWidget(),
+                                                                                      menuCustom.getPosition());
+                                                           } else {
+                                                               view.addMenuItem(getMenuItemId(menuCustom),
+                                                                                menuCustom.getCaption(),
+                                                                                parentId,
+                                                                                null,
+                                                                                menuCustom.getPosition());
+                                                           }
+                                                           setupEnableDisableMenuItem(menuCustom);
+                                                       }
 
-            @Override
-            public void visit( final MenuItemCommand menuItemCommand ) {
-                view.addMenuItem( getMenuItemId( menuItemCommand ), menuItemCommand.getCaption(), parentId, menuItemCommand.getCommand(), menuItemCommand.getPosition() );
-                setupEnableDisableMenuItem( menuItemCommand );
-            }
+                                                       @Override
+                                                       public void visit(final MenuItemCommand menuItemCommand) {
+                                                           view.addMenuItem(getMenuItemId(menuItemCommand),
+                                                                            menuItemCommand.getCaption(),
+                                                                            parentId,
+                                                                            menuItemCommand.getCommand(),
+                                                                            menuItemCommand.getPosition());
+                                                           setupEnableDisableMenuItem(menuItemCommand);
+                                                       }
 
-            @Override
-            public void visit( final MenuItemPerspective menuItemPerspective ) {
-                final String id = menuItemPerspective.getPlaceRequest().getIdentifier();
-                view.addMenuItem( id, menuItemPerspective.getCaption(), parentId, new Command() {
-                    @Override
-                    public void execute() {
-                        IOC.getBeanManager().lookupBean( PlaceManager.class ).getInstance().goTo( menuItemPerspective.getPlaceRequest() );
-                    }
-                }, menuItemPerspective.getPosition() );
-                setupEnableDisableMenuItem( menuItemPerspective );
-                final PlaceRequest placeRequest = menuItemPerspective.getPlaceRequest();
-                if ( perspectiveManager.getCurrentPerspective() != null && placeRequest.equals( perspectiveManager.getCurrentPerspective().getPlace() ) ) {
-                    view.selectMenuItem( id );
-                }
-            }
+                                                       @Override
+                                                       public void visit(final MenuItemPerspective menuItemPerspective) {
+                                                           final String id = menuItemPerspective.getPlaceRequest().getIdentifier();
+                                                           view.addMenuItem(id,
+                                                                            menuItemPerspective.getCaption(),
+                                                                            parentId,
+                                                                            new Command() {
+                                                                                @Override
+                                                                                public void execute() {
+                                                                                    IOC.getBeanManager().lookupBean(PlaceManager.class).getInstance().goTo(menuItemPerspective.getPlaceRequest());
+                                                                                }
+                                                                            },
+                                                                            menuItemPerspective.getPosition());
+                                                           setupEnableDisableMenuItem(menuItemPerspective);
+                                                           final PlaceRequest placeRequest = menuItemPerspective.getPlaceRequest();
+                                                           if (perspectiveManager.getCurrentPerspective() != null && placeRequest.equals(perspectiveManager.getCurrentPerspective().getPlace())) {
+                                                               view.selectMenuItem(id);
+                                                           }
+                                                       }
 
-            private void setupEnableDisableMenuItem( final MenuItem menuItem ) {
-                menuItem.addEnabledStateChangeListener( new EnabledStateChangeListener() {
-                    @Override
-                    public void enabledStateChanged( final boolean enabled ) {
-                        view.enableMenuItem( getMenuItemId( menuItem ),
-                                             enabled );
-                    }
-                } );
-            }
+                                                       private void setupEnableDisableMenuItem(final MenuItem menuItem) {
+                                                           menuItem.addEnabledStateChangeListener(new EnabledStateChangeListener() {
+                                                               @Override
+                                                               public void enabledStateChanged(final boolean enabled) {
+                                                                   view.enableMenuItem(getMenuItemId(menuItem),
+                                                                                       enabled);
+                                                               }
+                                                           });
+                                                       }
+                                                   }));
 
-        } ) );
-
-        synchronizeUIWithMenus( addedMenu.getItems() );
+        synchronizeUIWithMenus(addedMenu.getItems());
     }
 
-    private String getMenuItemId( final MenuItem menuItem ) {
+    private String getMenuItemId(final MenuItem menuItem) {
         return menuItem.getSignatureId() == null ? menuItem.getCaption() : menuItem.getSignatureId();
     }
 
-    private void addPerspectiveMenus( final PerspectiveActivity perspective ) {
+    protected void addPerspectiveMenus(final PerspectiveActivity perspective) {
         final String perspectiveId = perspective.getIdentifier();
         final Menus menus = perspective.getMenus();
         view.clearContextMenu();
-        if ( menus != null ) {
-            menus.accept( new AuthFilterMenuVisitor( authzManager, identity, new BaseMenuVisitor() {
+        if (menus != null) {
+            menus.accept(new AuthFilterMenuVisitor(authzManager,
+                                                   identity,
+                                                   new BaseMenuVisitor() {
 
-                private String parentId = null;
+                                                       private String parentId = null;
 
-                @Override
-                public boolean visitEnter( final MenuGroup menuGroup ) {
-                    parentId = getMenuItemId( menuGroup );
-                    view.addContextGroupMenuItem( perspectiveId, parentId, menuGroup.getCaption(), menuGroup.getPosition() );
-                    return true;
-                }
+                                                       @Override
+                                                       public boolean visitEnter(final MenuGroup menuGroup) {
+                                                           parentId = getMenuItemId(menuGroup);
+                                                           view.addContextGroupMenuItem(perspectiveId,
+                                                                                        parentId,
+                                                                                        menuGroup.getCaption(),
+                                                                                        menuGroup.getPosition());
+                                                           return true;
+                                                       }
 
-                @Override
-                public void visitLeave( MenuGroup menuGroup ) {
-                    parentId = null;
-                }
+                                                       @Override
+                                                       public void visitLeave(MenuGroup menuGroup) {
+                                                           parentId = null;
+                                                       }
 
-                @Override
-                public void visit( final MenuItemPlain menuItemPlain ) {
-                    view.addContextMenuItem( perspectiveId, getMenuItemId( menuItemPlain ), menuItemPlain.getCaption(), parentId, null, menuItemPlain.getPosition() );
-                    setupEnableDisableContextMenuItem( menuItemPlain );
-                }
+                                                       @Override
+                                                       public void visit(final MenuItemPlain menuItemPlain) {
+                                                           view.addContextMenuItem(perspectiveId,
+                                                                                   getMenuItemId(menuItemPlain),
+                                                                                   menuItemPlain.getCaption(),
+                                                                                   parentId,
+                                                                                   null,
+                                                                                   menuItemPlain.getPosition());
+                                                           setupEnableDisableContextMenuItem(menuItemPlain);
+                                                       }
 
-                @Override
-                public void visit( final MenuCustom<?> menuCustom ) {
-                    view.addContextMenuItem( perspectiveId, getMenuItemId( menuCustom ), menuCustom.getCaption(), parentId, null, menuCustom.getPosition() );
-                    setupEnableDisableContextMenuItem( menuCustom );
-                }
+                                                       @Override
+                                                       public void visit(final MenuCustom<?> menuCustom) {
+                                                           view.addContextMenuItem(perspectiveId,
+                                                                                   getMenuItemId(menuCustom),
+                                                                                   menuCustom.getCaption(),
+                                                                                   parentId,
+                                                                                   null,
+                                                                                   menuCustom.getPosition());
+                                                           setupEnableDisableContextMenuItem(menuCustom);
+                                                       }
 
-                @Override
-                public void visit( final MenuItemCommand menuItemCommand ) {
-                    view.addContextMenuItem( perspectiveId, getMenuItemId( menuItemCommand ), menuItemCommand.getCaption(), parentId, menuItemCommand.getCommand(), menuItemCommand.getPosition() );
-                    setupEnableDisableContextMenuItem( menuItemCommand );
-                }
+                                                       @Override
+                                                       public void visit(final MenuItemCommand menuItemCommand) {
+                                                           view.addContextMenuItem(perspectiveId,
+                                                                                   getMenuItemId(menuItemCommand),
+                                                                                   menuItemCommand.getCaption(),
+                                                                                   parentId,
+                                                                                   menuItemCommand.getCommand(),
+                                                                                   menuItemCommand.getPosition());
+                                                           setupEnableDisableContextMenuItem(menuItemCommand);
+                                                       }
 
-                @Override
-                public void visit( final MenuItemPerspective menuItemPerspective ) {
-                    view.addContextMenuItem( perspectiveId, menuItemPerspective.getPlaceRequest().getIdentifier(), menuItemPerspective.getCaption(), parentId, new Command() {
-                        @Override
-                        public void execute() {
-                            IOC.getBeanManager().lookupBean( PlaceManager.class ).getInstance().goTo( menuItemPerspective.getPlaceRequest() );
-                        }
-                    }, menuItemPerspective.getPosition() );
-                    setupEnableDisableContextMenuItem( menuItemPerspective );
-                }
+                                                       @Override
+                                                       public void visit(final MenuItemPerspective menuItemPerspective) {
+                                                           view.addContextMenuItem(perspectiveId,
+                                                                                   menuItemPerspective.getPlaceRequest().getIdentifier(),
+                                                                                   menuItemPerspective.getCaption(),
+                                                                                   parentId,
+                                                                                   new Command() {
+                                                                                       @Override
+                                                                                       public void execute() {
+                                                                                           IOC.getBeanManager().lookupBean(PlaceManager.class).getInstance().goTo(menuItemPerspective.getPlaceRequest());
+                                                                                       }
+                                                                                   },
+                                                                                   menuItemPerspective.getPosition());
+                                                           setupEnableDisableContextMenuItem(menuItemPerspective);
+                                                       }
 
-                private void setupEnableDisableContextMenuItem( final MenuItem menuItem ) {
-                    menuItem.addEnabledStateChangeListener( new EnabledStateChangeListener() {
-                        @Override
-                        public void enabledStateChanged( final boolean enabled ) {
-                            view.enableContextMenuItem( getMenuItemId( menuItem ),
-                                                        enabled );
-                        }
-                    } );
-                }
+                                                       private void setupEnableDisableContextMenuItem(final MenuItem menuItem) {
+                                                           menuItem.addEnabledStateChangeListener(new EnabledStateChangeListener() {
+                                                               @Override
+                                                               public void enabledStateChanged(final boolean enabled) {
+                                                                   view.enableContextMenuItem(getMenuItemId(menuItem),
+                                                                                              enabled);
+                                                               }
+                                                           });
+                                                       }
+                                                   }));
 
-            } ) );
-
-            synchronizeUIWithMenus( menus.getItems() );
+            synchronizeUIWithMenus(menus.getItems());
         }
     }
 
-    protected void onPerspectiveChange( @Observes final PerspectiveChange perspectiveChange ) {
-        final Activity activity = activityManager.getActivity( perspectiveChange.getPlaceRequest() );
-        if ( activity instanceof PerspectiveActivity ) {
-            addPerspectiveMenus( (PerspectiveActivity) activity );
+    protected void onPerspectiveChange(final PerspectiveChange perspectiveChange) {
+        final Activity activity = activityManager.getActivity(perspectiveChange.getPlaceRequest());
+        if (activity instanceof PerspectiveActivity) {
+            addPerspectiveMenus((PerspectiveActivity) activity);
         }
-        view.selectMenuItem( perspectiveChange.getPlaceRequest().getIdentifier() );
+        view.selectMenuItem(perspectiveChange.getPlaceRequest().getIdentifier());
     }
 
-    protected void onPlaceMinimized( @Observes final PlaceMinimizedEvent event ) {
-        if ( isUseExpandedMode() ) {
+    protected void onPlaceMinimized(final PlaceMinimizedEvent event) {
+        if (isUseExpandedMode()) {
             view.expand();
         }
     }
 
-    protected void onPlaceMaximized( @Observes final PlaceMaximizedEvent event ) {
+    protected void onPlaceMaximized(final PlaceMaximizedEvent event) {
         view.collapse();
     }
 
@@ -379,13 +372,13 @@ public class WorkbenchMenuBarPresenter implements WorkbenchMenuBar {
     }
 
     @Override
-    public void addCollapseHandler( final Command command ) {
-        view.addCollapseHandler( command );
+    public void addCollapseHandler(final Command command) {
+        view.addCollapseHandler(command);
     }
 
     @Override
-    public void addExpandHandler( final Command command ) {
-        view.addExpandHandler( command );
+    public void addExpandHandler(final Command command) {
+        view.addExpandHandler(command);
     }
 
     List<Menus> getAddedMenus() {
@@ -393,15 +386,61 @@ public class WorkbenchMenuBarPresenter implements WorkbenchMenuBar {
     }
 
     //Force UI to update to state of MenuItems. Should be called after MenuItems are configured with EnabledStateChangeListener's.
-    void synchronizeUIWithMenus( final List<MenuItem> menuItems ) {
-        for ( MenuItem menuItem : menuItems ) {
-            if ( menuItem instanceof MenuGroup ) {
-                synchronizeUIWithMenus( ( (MenuGroup) menuItem ).getItems() );
-
+    void synchronizeUIWithMenus(final List<MenuItem> menuItems) {
+        for (MenuItem menuItem : menuItems) {
+            if (menuItem instanceof MenuGroup) {
+                synchronizeUIWithMenus(((MenuGroup) menuItem).getItems());
             } else {
-                menuItem.setEnabled( menuItem.isEnabled() );
+                menuItem.setEnabled(menuItem.isEnabled());
             }
         }
+    }
 
+    public interface View extends IsWidget {
+
+        void clear();
+
+        void addMenuItem(String id,
+                         String label,
+                         String parentId,
+                         Command command,
+                         MenuPosition position);
+
+        void addCustomMenuItem(Widget menu,
+                               MenuPosition position);
+
+        void addGroupMenuItem(String id,
+                              String label,
+                              MenuPosition position);
+
+        void selectMenuItem(String id);
+
+        void addContextMenuItem(String menuItemId,
+                                String id,
+                                String label,
+                                String parentId,
+                                Command command,
+                                MenuPosition position);
+
+        void addContextGroupMenuItem(String menuItemId,
+                                     String id,
+                                     String label,
+                                     MenuPosition position);
+
+        void clearContextMenu();
+
+        void expand();
+
+        void collapse();
+
+        void addCollapseHandler(Command command);
+
+        void addExpandHandler(Command command);
+
+        void enableMenuItem(String menuItemId,
+                            boolean enabled);
+
+        void enableContextMenuItem(String menuItemId,
+                                   boolean enabled);
     }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarProducer.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarProducer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.workbench.widgets.menu;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import com.google.gwt.user.client.Window;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.uberfire.client.mvp.ActivityManager;
+import org.uberfire.client.mvp.PerspectiveManager;
+import org.uberfire.client.workbench.events.PerspectiveChange;
+import org.uberfire.client.workbench.events.PlaceMaximizedEvent;
+import org.uberfire.client.workbench.events.PlaceMinimizedEvent;
+import org.uberfire.security.authz.AuthorizationManager;
+
+@ApplicationScoped
+public class WorkbenchMenuBarProducer {
+
+    private AuthorizationManager authzManager;
+    private PerspectiveManager perspectiveManager;
+    private ActivityManager activityManager;
+    private User identity;
+    private WorkbenchMenuBarPresenter.View view;
+    private WorkbenchMenuBarPresenter instance = null;
+
+    public WorkbenchMenuBarProducer() {
+        //CDI proxy
+    }
+
+    @Inject
+    public WorkbenchMenuBarProducer(final AuthorizationManager authzManager,
+                                    final PerspectiveManager perspectiveManager,
+                                    final ActivityManager activityManager,
+                                    final User identity,
+                                    final WorkbenchMenuBarPresenter.View view) {
+        this.authzManager = authzManager;
+        this.perspectiveManager = perspectiveManager;
+        this.activityManager = activityManager;
+        this.identity = identity;
+        this.view = view;
+    }
+
+    @Produces
+    public WorkbenchMenuBarPresenter getWorkbenchMenuBar() {
+        if (instance == null) {
+            if (!isStandalone()) {
+                instance = makeDefaultMenuBarPresenter();
+            } else {
+                instance = makeStandaloneMenuBarPresenter();
+            }
+        }
+        return instance;
+    }
+
+    WorkbenchMenuBarPresenter makeDefaultMenuBarPresenter() {
+        return new WorkbenchMenuBarPresenter(authzManager,
+                                             perspectiveManager,
+                                             activityManager,
+                                             identity,
+                                             view);
+    }
+
+    WorkbenchMenuBarPresenter makeStandaloneMenuBarPresenter() {
+        return new WorkbenchMenuBarStandalonePresenter(authzManager,
+                                                       perspectiveManager,
+                                                       activityManager,
+                                                       identity,
+                                                       view);
+    }
+
+    protected void onPerspectiveChange(final @Observes PerspectiveChange perspectiveChange) {
+        if (instance != null) {
+            instance.onPerspectiveChange(perspectiveChange);
+        }
+    }
+
+    protected void onPlaceMinimized(final @Observes PlaceMinimizedEvent event) {
+        if (instance != null) {
+            instance.onPlaceMinimized(event);
+        }
+    }
+
+    protected void onPlaceMaximized(final @Observes PlaceMaximizedEvent event) {
+        if (instance != null) {
+            instance.onPlaceMaximized(event);
+        }
+    }
+
+    boolean isStandalone() {
+        return Window.Location.getParameterMap().containsKey("standalone");
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarStandalonePresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarStandalonePresenter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.workbench.widgets.menu;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.uberfire.client.mvp.ActivityManager;
+import org.uberfire.client.mvp.PerspectiveActivity;
+import org.uberfire.client.mvp.PerspectiveManager;
+import org.uberfire.security.authz.AuthorizationManager;
+import org.uberfire.workbench.model.menu.Menus;
+
+public class WorkbenchMenuBarStandalonePresenter extends WorkbenchMenuBarPresenter {
+
+    WorkbenchMenuBarStandalonePresenter(final AuthorizationManager authzManager,
+                                        final PerspectiveManager perspectiveManager,
+                                        final ActivityManager activityManager,
+                                        final User identity,
+                                        final View view) {
+        super(authzManager,
+              perspectiveManager,
+              activityManager,
+              identity,
+              view);
+    }
+
+    @Override
+    public void addMenus(final Menus menus) {
+        //Do nothing. Standalone mode does not use top-level menu items
+    }
+
+    @Override
+    protected void addPerspectiveMenus(final PerspectiveActivity perspective) {
+        final Menus menus = perspective.getMenus();
+        super.addMenus(menus);
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarProducerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarProducerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.workbench.widgets.menu;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.client.mvp.ActivityManager;
+import org.uberfire.client.mvp.PerspectiveManager;
+import org.uberfire.client.workbench.events.PerspectiveChange;
+import org.uberfire.client.workbench.events.PlaceMaximizedEvent;
+import org.uberfire.client.workbench.events.PlaceMinimizedEvent;
+import org.uberfire.security.authz.AuthorizationManager;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WorkbenchMenuBarProducerTest {
+
+    @Mock
+    private AuthorizationManager authzManager;
+
+    @Mock
+    private PerspectiveManager perspectiveManager;
+
+    @Mock
+    private ActivityManager activityManager;
+
+    @Mock
+    private User identity;
+
+    @Mock
+    private WorkbenchMenuBarPresenter.View view;
+
+    @Mock
+    private WorkbenchMenuBarPresenter defaultPresenter;
+
+    @Mock
+    private WorkbenchMenuBarStandalonePresenter standalonePresenter;
+
+    @Mock
+    private PerspectiveChange perspectiveChangeEvent;
+
+    @Mock
+    private PlaceMaximizedEvent placeMaximizedEvent;
+
+    @Mock
+    private PlaceMinimizedEvent placeMinimizedEvent;
+
+    private WorkbenchMenuBarProducer producer;
+    private boolean isStandalone = false;
+
+    @Before
+    public void setup() {
+        producer = new WorkbenchMenuBarProducer(authzManager,
+                                                perspectiveManager,
+                                                activityManager,
+                                                identity,
+                                                view) {
+            @Override
+            boolean isStandalone() {
+                return isStandalone;
+            }
+
+            @Override
+            WorkbenchMenuBarPresenter makeDefaultMenuBarPresenter() {
+                return defaultPresenter;
+            }
+
+            @Override
+            WorkbenchMenuBarPresenter makeStandaloneMenuBarPresenter() {
+                return standalonePresenter;
+            }
+        };
+    }
+
+    @Test
+    public void menuBarPresenterInstantiationDefaultMode() {
+        assertMenuBarPresenter(false,
+                               WorkbenchMenuBarPresenter.class);
+    }
+
+    @Test
+    public void menuBarPresenterInstantiationStandaloneMode() {
+        assertMenuBarPresenter(true,
+                               WorkbenchMenuBarStandalonePresenter.class);
+    }
+
+    @Test
+    public void checkObservedEventsCallsPresenterDefaultMode() {
+        final WorkbenchMenuBarPresenter presenter = getMenuBarPresenter(false);
+        assertMenuBarEvents(presenter);
+    }
+
+    @Test
+    public void checkObservedEventsCallsPresenterStandaloneMode() {
+        final WorkbenchMenuBarPresenter presenter = getMenuBarPresenter(true);
+        assertMenuBarEvents(presenter);
+    }
+
+    private void assertMenuBarPresenter(final boolean isStandalone,
+                                        final Class expectedPresenterType) {
+        final WorkbenchMenuBarPresenter presenter = getMenuBarPresenter(isStandalone);
+        assertEquals(extractContainingClassName(expectedPresenterType.getName()),
+                     extractContainingClassName(presenter.getClass().getName()));
+    }
+
+    private void assertMenuBarEvents(final WorkbenchMenuBarPresenter presenter) {
+        presenter.onPerspectiveChange(perspectiveChangeEvent);
+        verify(presenter).onPerspectiveChange(eq(perspectiveChangeEvent));
+
+        presenter.onPlaceMaximized(placeMaximizedEvent);
+        verify(presenter).onPlaceMaximized(eq(placeMaximizedEvent));
+
+        presenter.onPlaceMinimized(placeMinimizedEvent);
+        verify(presenter).onPlaceMinimized(eq(placeMinimizedEvent));
+    }
+
+    private WorkbenchMenuBarPresenter getMenuBarPresenter(final boolean isStandalone) {
+        this.isStandalone = isStandalone;
+        return producer.getWorkbenchMenuBar();
+    }
+
+    private String extractContainingClassName(final String className) {
+        if (className.contains("$$")) {
+            return className.substring(0,
+                                       className.indexOf("$$"));
+        }
+        return className;
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarStandalonePresenterTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarStandalonePresenterTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.workbench.widgets.menu;
+
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.client.mvp.ActivityManager;
+import org.uberfire.client.mvp.PerspectiveActivity;
+import org.uberfire.client.mvp.PerspectiveManager;
+import org.uberfire.client.workbench.events.PerspectiveChange;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.security.authz.AuthorizationManager;
+import org.uberfire.workbench.model.menu.MenuFactory;
+import org.uberfire.workbench.model.menu.MenuItem;
+import org.uberfire.workbench.model.menu.MenuPosition;
+import org.uberfire.workbench.model.menu.Menus;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WorkbenchMenuBarStandalonePresenterTest {
+
+    @Mock
+    protected AuthorizationManager authzManager;
+    @Mock
+    protected User identity;
+    @Mock
+    private PerspectiveManager perspectiveManager;
+    @Mock
+    private ActivityManager activityManager;
+
+    @Mock
+    private WorkbenchMenuBarPresenter.View view;
+
+    @InjectMocks
+    private WorkbenchMenuBarStandalonePresenter presenter;
+
+    @Test
+    public void testAddMenus() {
+        final String perspectiveId = "perspectiveId";
+        final String label = "perspectiveLabel";
+        final Menus menus = MenuFactory.newSimpleItem(label).perspective(perspectiveId).endMenu().build();
+        when(authzManager.authorize(menus.getItems().get(0),
+                                    identity)).thenReturn(true);
+
+        presenter.addMenus(menus);
+
+        verify(authzManager,
+               never()).authorize(any(MenuItem.class),
+                                  any(User.class));
+        verify(view,
+               never()).addMenuItem(anyString(),
+                                    anyString(),
+                                    anyString(),
+                                    any(Command.class),
+                                    any(MenuPosition.class));
+    }
+
+    @Test
+    public void testAddContextMenus() {
+        final String perspectiveId = "perspectiveId";
+        final String contextLabel = "contextLabel";
+        final Menus contextMenus = MenuFactory.newSimpleItem(contextLabel).endMenu().build();
+        final PerspectiveActivity activity = mock(PerspectiveActivity.class);
+        final PlaceRequest placeRequest = mock(PlaceRequest.class);
+
+        when(activity.getIdentifier()).thenReturn(perspectiveId);
+        when(activity.getMenus()).thenReturn(contextMenus);
+        when(authzManager.authorize(contextMenus.getItems().get(0),
+                                    identity)).thenReturn(true);
+        when(activityManager.getActivity(placeRequest)).thenReturn(activity);
+
+        presenter.onPerspectiveChange(new PerspectiveChange(placeRequest,
+                                                            null,
+                                                            contextMenus,
+                                                            perspectiveId));
+
+        verify(authzManager).authorize(contextMenus.getItems().get(0),
+                                       identity);
+        verify(view).addMenuItem(anyString(),
+                                 eq(contextLabel),
+                                 isNull(String.class),
+                                 isNull(Command.class),
+                                 eq(MenuPosition.LEFT));
+
+        verify(view,
+               never()).clearContextMenu();
+        verify(view,
+               never()).addContextMenuItem(anyString(),
+                                           anyString(),
+                                           anyString(),
+                                           anyString(),
+                                           any(Command.class),
+                                           any(MenuPosition.class));
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBPMS-4706

This PR moves instantiation of the "Menu bar" to a helper to provide a different implementation for "default" vs "standalone" modes of operation (i.e. when workbench URL contains the ```standalone=true``` parameter). Tried and tested with (6.5.x) ```kie-wb``` and ```kie-drools-wb``` both "default" and "standalone" modes.. all OK.