### PR TITLE
Uberfire breadcrumbs adds extra space between navbar and perspective content

### DIFF
--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/UberfireBreadcrumbs.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/UberfireBreadcrumbs.java
@@ -26,13 +26,13 @@ import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.HasWidgets;
 import org.jboss.errai.common.client.dom.Element;
+import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.UberElement;
-import org.uberfire.client.workbench.docks.UberfireDockContainerReadyEvent;
-import org.uberfire.client.workbench.docks.UberfireDocksContainer;
 import org.uberfire.client.workbench.events.PerspectiveChange;
+import org.uberfire.ext.widgets.common.client.breadcrumbs.header.UberfireBreadcrumbsContainer;
 import org.uberfire.ext.widgets.common.client.breadcrumbs.widget.BreadcrumbsPresenter;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
@@ -51,22 +51,20 @@ import org.uberfire.mvp.PlaceRequest;
 @EntryPoint
 public class UberfireBreadcrumbs {
 
-    public static final double SIZE = 35.0;
     final Map<String, List<BreadcrumbsPresenter>> breadcrumbsPerPerspective = new HashMap<>();
     final Map<String, Element> breadcrumbsToolBarPerPerspective = new HashMap<>();
-    private final UberfireDocksContainer uberfireDocksContainer;
+    private final UberfireBreadcrumbsContainer uberfireBreadcrumbsContainer;
     private final View view;
     String currentPerspective;
     private ManagedInstance<BreadcrumbsPresenter> breadcrumbsPresenters;
-
     private PlaceManager placeManager;
 
     @Inject
-    public UberfireBreadcrumbs(UberfireDocksContainer uberfireDocksContainer,
+    public UberfireBreadcrumbs(UberfireBreadcrumbsContainer uberfireBreadcrumbsContainer,
                                ManagedInstance<BreadcrumbsPresenter> breadcrumbsPresenters,
                                PlaceManager placeManager,
                                View view) {
-        this.uberfireDocksContainer = uberfireDocksContainer;
+        this.uberfireBreadcrumbsContainer = uberfireBreadcrumbsContainer;
         this.breadcrumbsPresenters = breadcrumbsPresenters;
         this.placeManager = placeManager;
         this.view = view;
@@ -77,13 +75,9 @@ public class UberfireBreadcrumbs {
         updateView();
     }
 
-    void setup(@Observes UberfireDockContainerReadyEvent event) {
-        createBreadCrumbs();
-    }
-
-    private void createBreadCrumbs() {
-        uberfireDocksContainer.addBreadcrumbs(getView(),
-                                              SIZE);
+    @AfterInitialization
+    public void createBreadCrumbs() {
+        uberfireBreadcrumbsContainer.init(getView().getElement());
     }
 
     /**
@@ -297,6 +291,12 @@ public class UberfireBreadcrumbs {
 
     View getView() {
         view.clear();
+        updateBreadCrumbsContainer();
+        updateBreadcrumbs();
+        return view;
+    }
+
+    private void updateBreadcrumbs() {
         if (thereIsBreadcrumbsFor(currentPerspective)) {
             breadcrumbsPerPerspective.get(currentPerspective)
                     .stream()
@@ -305,7 +305,18 @@ public class UberfireBreadcrumbs {
         if (thereIsBreadcrumbToolbarFor(currentPerspective)) {
             view.addBreadcrumbToolbar(breadcrumbsToolBarPerPerspective.get(currentPerspective));
         }
-        return view;
+    }
+
+    void updateBreadCrumbsContainer() {
+        if (thereIsContentOnBreadcrumbs()) {
+            uberfireBreadcrumbsContainer.enable();
+        } else {
+            uberfireBreadcrumbsContainer.disable();
+        }
+    }
+
+    private boolean thereIsContentOnBreadcrumbs() {
+        return thereIsBreadcrumbsFor(currentPerspective) || thereIsBreadcrumbToolbarFor(currentPerspective);
     }
 
     private boolean thereIsBreadcrumbsFor(final String perspective) {

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/header/UberfireBreadcrumbsContainer.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/header/UberfireBreadcrumbsContainer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.widgets.common.client.breadcrumbs.header;
+
+import org.jboss.errai.common.client.dom.HTMLElement;
+
+public interface UberfireBreadcrumbsContainer {
+
+    void init(HTMLElement child);
+
+    void enable();
+
+    void disable();
+}

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/header/UberfireBreadcrumbsContainerImpl.css
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/header/UberfireBreadcrumbsContainerImpl.css
@@ -1,0 +1,8 @@
+.breadcrumbs-container {
+    height: 35px;
+    width: 100%;
+}
+
+.breadcrumb-disabled {
+    display: none;
+}

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/header/UberfireBreadcrumbsContainerImpl.html
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/header/UberfireBreadcrumbsContainerImpl.html
@@ -1,0 +1,2 @@
+<div data-field="breadcrumbs-container" class="breadcrumbs-container">
+</div>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/header/UberfireBreadcrumbsContainerImpl.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/header/UberfireBreadcrumbsContainerImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.widgets.common.client.breadcrumbs.header;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.dom.DOMUtil;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.common.client.dom.HTMLElement;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.uberfire.client.workbench.Header;
+
+@ApplicationScoped
+@Templated
+public class UberfireBreadcrumbsContainerImpl implements Header,
+                                                         UberfireBreadcrumbsContainer {
+
+    @Inject
+    @DataField("breadcrumbs-container")
+    Div breadcrumbsContainer;
+
+    @Override
+    public void init(HTMLElement child) {
+        DOMUtil.removeAllChildren(breadcrumbsContainer);
+        breadcrumbsContainer.appendChild(child);
+    }
+
+    @Override
+    public String getId() {
+        return "UberfireBreadcrumbsContainer";
+    }
+
+    @Override
+    public int getOrder() {
+        return 10;
+    }
+
+    @Override
+    public void enable() {
+        DOMUtil.removeCSSClass(breadcrumbsContainer,
+                               "breadcrumb-disabled");
+    }
+
+    @Override
+    public void disable() {
+        DOMUtil.addCSSClass(breadcrumbsContainer,
+                            "breadcrumb-disabled");
+    }
+}
+

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/breadcrumbs/UberfireBreadcrumbsTest.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/breadcrumbs/UberfireBreadcrumbsTest.java
@@ -23,6 +23,7 @@ import com.google.gwt.user.client.ui.HasWidgets;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.jboss.errai.common.client.api.IsElement;
 import org.jboss.errai.common.client.dom.Element;
+import org.jboss.errai.common.client.dom.HTMLElement;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +33,7 @@ import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.client.workbench.docks.UberfireDockContainerReadyEvent;
 import org.uberfire.client.workbench.docks.UberfireDocksContainer;
+import org.uberfire.ext.widgets.common.client.breadcrumbs.header.UberfireBreadcrumbsContainer;
 import org.uberfire.ext.widgets.common.client.breadcrumbs.widget.BreadcrumbsPresenter;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
@@ -44,7 +46,7 @@ import static org.mockito.Mockito.*;
 public class UberfireBreadcrumbsTest {
 
     @Mock
-    private UberfireDocksContainer uberfireDocksContainer;
+    private UberfireBreadcrumbsContainer uberfireBreadcrumbsContainer;
 
     @Mock
     private ManagedInstance<BreadcrumbsPresenter> breadcrumbsPresenters;
@@ -62,7 +64,7 @@ public class UberfireBreadcrumbsTest {
                 .thenReturn(mock(BreadcrumbsPresenter.class)).thenReturn(mock(BreadcrumbsPresenter.class));
 
         view = mock(UberfireBreadcrumbs.View.class);
-        uberfireBreadcrumbs = spy(new UberfireBreadcrumbs(uberfireDocksContainer,
+        uberfireBreadcrumbs = spy(new UberfireBreadcrumbs(uberfireBreadcrumbsContainer,
                                                           breadcrumbsPresenters,
                                                           placeManager,
                                                           view) {
@@ -70,12 +72,10 @@ public class UberfireBreadcrumbsTest {
     }
 
     @Test
-    public void setupTest() {
-        uberfireBreadcrumbs.setup(new UberfireDockContainerReadyEvent());
+    public void createBreadCrumbsTest() {
+        uberfireBreadcrumbs.createBreadCrumbs();
 
-        assertNotNull(uberfireBreadcrumbs);
-        verify(uberfireDocksContainer).addBreadcrumbs(any(IsElement.class),
-                                                      eq(UberfireBreadcrumbs.SIZE));
+        verify(uberfireBreadcrumbsContainer).init(any(HTMLElement.class));
     }
 
     @Test
@@ -297,5 +297,28 @@ public class UberfireBreadcrumbsTest {
                                                   new DefaultPlaceRequest("screen"),
                                                   null,
                                                   command);
+    }
+
+    @Test
+    public void updateBreadCrumbsContainerTest() {
+        assertTrue(uberfireBreadcrumbs.breadcrumbsPerPerspective.isEmpty());
+
+        uberfireBreadcrumbs.currentPerspective = "myperspective";
+        uberfireBreadcrumbs.addBreadCrumb("myperspective",
+                                          "label",
+                                          new DefaultPlaceRequest("screen"));
+
+        verify(uberfireBreadcrumbsContainer).enable();
+    }
+
+    @Test
+    public void updateBreadCrumbsWithNoBreadcrumbsContainerTest() {
+        assertTrue(uberfireBreadcrumbs.breadcrumbsPerPerspective.isEmpty());
+
+        uberfireBreadcrumbs.currentPerspective = "myperspective";
+
+        uberfireBreadcrumbs.updateBreadCrumbsContainer();
+
+        verify(uberfireBreadcrumbsContainer).disable();
     }
 }


### PR DESCRIPTION
This PR remove the blank workbench space and move breadcrumbs for a header.

https://issues.jboss.org/browse/UF-462

