### PR TITLE
Avoid unnecessary repetitive calls to Pattern.compile()

### DIFF
--- a/uberfire-extensions/uberfire-apps/uberfire-apps-client/src/main/java/org/uberfire/ext/apps/client/home/components/popup/DirectoryNameValidator.java
+++ b/uberfire-extensions/uberfire-apps/uberfire-apps-client/src/main/java/org/uberfire/ext/apps/client/home/components/popup/DirectoryNameValidator.java
@@ -19,9 +19,12 @@ package org.uberfire.ext.apps.client.home.components.popup;
 import org.uberfire.ext.apps.api.Directory;
 import org.uberfire.ext.apps.client.resources.i18n.CommonConstants;
 
+import java.util.regex.Pattern;
+
 public class DirectoryNameValidator {
 
     public static final String VALID_DIR_REGEX = "^([^*\"\\/><?\\\\\\!|;:]*)$";
+    private static final Pattern VALID_DIR_PATTERN = Pattern.compile(VALID_DIR_REGEX);
     private final Directory currentDirectory;
 
     public DirectoryNameValidator(Directory currentDirectory) {
@@ -36,7 +39,7 @@ public class DirectoryNameValidator {
         if (dirName == null || dirName.trim().isEmpty()) {
             return Boolean.FALSE;
         }
-        if (!dirName.matches(VALID_DIR_REGEX)) {
+        if (!VALID_DIR_PATTERN.matcher(dirName).matches()) {
             return Boolean.FALSE;
         }
         if (currentDirectory.alreadyHasChild(dirName)) {

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/validation/ValidationUtils.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/validation/ValidationUtils.java
@@ -18,6 +18,7 @@ package org.uberfire.ext.editor.commons.backend.validation;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.regex.Pattern;
 import javax.lang.model.SourceVersion;
 
 import org.apache.commons.lang3.CharUtils;
@@ -26,7 +27,8 @@ import org.apache.commons.lang3.StringUtils;
 public class ValidationUtils {
 
     private static final char[] ILLEGAL_CHARACTERS = {'/', '\n', '\r', '\t', '\0', '\f', '`', '?', '*', '\\', '<', '>', '|', '\"', ':'};
-
+    // See org.apache.maven.model.validation.DefaultModelValidator.java::ID_REGEX
+    private static final Pattern ARTIFACT_ID_PATTERN = Pattern.compile("[A-Za-z0-9_\\-.]+");
     public static boolean isFileName(final String value) {
         //Null check
         if (StringUtils.isBlank(value)) {
@@ -40,7 +42,7 @@ public class ValidationUtils {
 
         //Illegal character check
         for (Character c : ILLEGAL_CHARACTERS) {
-            if (value.contains(c.toString())) {
+            if (value.indexOf(c) != -1) {
                 return false;
             }
         }
@@ -70,7 +72,6 @@ public class ValidationUtils {
     }
 
     public static boolean isArtifactIdentifier(final String value) {
-        // See org.apache.maven.model.validation.DefaultModelValidator.java::ID_REGEX
-        return value != null && value.matches("[A-Za-z0-9_\\-.]+");
+        return value != null && ARTIFACT_ID_PATTERN.matcher(value).matches();
     }
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/infra/NameValidator.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/infra/NameValidator.java
@@ -17,9 +17,12 @@ package org.uberfire.ext.layout.editor.client.infra;
 
 import org.uberfire.ext.layout.editor.client.resources.i18n.CommonConstants;
 
+import java.util.regex.Pattern;
+
 public class NameValidator {
 
     public static final String VALID_DIR_REGEX = "^([^*\"\\/><?\\\\\\!|;:]*)$";
+    private static final Pattern VALID_DIR_PATTERN = Pattern.compile(VALID_DIR_REGEX);
 
     private String error;
 
@@ -55,7 +58,7 @@ public class NameValidator {
         if (dirName == null || dirName.isEmpty()) {
             return Boolean.FALSE;
         }
-        if (!dirName.matches(VALID_DIR_REGEX)) {
+        if (!VALID_DIR_PATTERN.matcher(dirName).matches()) {
             return Boolean.FALSE;
         }
         return Boolean.TRUE;

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/validation/NameValidator.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/validation/NameValidator.java
@@ -17,9 +17,12 @@ package org.uberfire.ext.plugin.client.validation;
 
 import org.uberfire.ext.plugin.client.resources.i18n.CommonConstants;
 
+import java.util.regex.Pattern;
+
 public class NameValidator extends RuleValidator {
 
     public static final String VALID_DIR_REGEX = "^([^*\"\\/><?\\\\\\!|;:]*)$";
+    private static final Pattern VALID_DIR_PATTERN = Pattern.compile(VALID_DIR_REGEX);
 
     private String emptyError;
 
@@ -59,7 +62,7 @@ public class NameValidator extends RuleValidator {
             return Boolean.FALSE;
         }
 
-        if (!dirName.matches(VALID_DIR_REGEX)) {
+        if (!VALID_DIR_PATTERN.matcher(dirName).matches()) {
             this.error = this.invalidError;
             return Boolean.FALSE;
         }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
@@ -47,6 +47,7 @@ import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.jcraft.jsch.Session;
@@ -221,6 +222,7 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
     public static final String DEFAULT_COMMIT_LIMIT_TO_GC = "20";
     protected static final String DEFAULT_IO_SERVICE_NAME = "default";
     private static final Logger LOG = LoggerFactory.getLogger(JGitFileSystemProvider.class);
+    private static final Pattern FORK_ORIGIN_PATTERN = Pattern.compile("(^\\w+\\/\\w+$)");
     private static final String SCHEME = "git";
     private static final int SCHEME_SIZE = (SCHEME + "://").length();
     private static final int DEFAULT_SCHEME_SIZE = ("default://").length();
@@ -924,7 +926,7 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
     }
 
     private boolean isForkOrigin(final String originURI) {
-        return originURI.matches("(^\\w+\\/\\w+$)");
+        return FORK_ORIGIN_PATTERN.matcher(originURI).matches();
     }
 
     private void migrateOldRepository(String oldName,

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/base/AbstractPath.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/base/AbstractPath.java
@@ -91,7 +91,7 @@ public abstract class AbstractPath<FS extends FileSystem>
                                  host);
         this.isRealPath = isRealPath;
         this.isNormalized = isNormalized;
-        this.usesWindowsFormat = path.matches(".*\\\\.*");
+        this.usesWindowsFormat = path.indexOf('\\') != -1;
 
         final RootInfo rootInfo = setupRoot(fs,
                                             path,


### PR DESCRIPTION
@porcelli please take a look and consider merging this.

Code using `<some string>.matches("regex")` internally calls `Pattern.compile(regex).matcher(input).matches()` The regex compilation step is much more expensive compared to matching step. Caching the Pattern (or avoiding regexes in some cases) will improve performance in these often-called cases.