### PR TITLE
UF-512: Index test randomly failing

### DIFF
--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
@@ -230,7 +230,7 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
         super.dispose();
     }
 
-    private void setupWatchService(final FileSystem fs) {
+    protected void setupWatchService(final FileSystem fs) {
         if (watchedList.contains(fs)) {
             return;
         }


### PR DESCRIPTION
See https://issues.jboss.org/browse/UF-512

On investigation it appeared the ```WatchService``` was leading to the repository to be indexed in response to ```ioService().write(path1, "xxx!")``` before batch indexing's test threads had a chance to run. The test disables ```WatchService``` and just requests the ```FileSystem``` (which leads to batch indexing to execute). The test now also verifies there were 3 attempts to invoke indexing; and only one runs.