### PR TITLE
Avoid unnecessary Pattern.compile() in AbstractPath

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/base/AbstractPath.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/base/AbstractPath.java
@@ -91,7 +91,7 @@ public abstract class AbstractPath<FS extends FileSystem>
                                  host);
         this.isRealPath = isRealPath;
         this.isNormalized = isNormalized;
-        this.usesWindowsFormat = path.matches(".*\\\\.*");
+        this.usesWindowsFormat = path.indexOf('\\') != -1;
 
         final RootInfo rootInfo = setupRoot(fs,
                                             path,


### PR DESCRIPTION
Sorry for the trouble this commit caused in https://github.com/AppFormer/uberfire/pull/694. I didn't realize that client-side doesn't support that. That being said I still think that this server-side change in AbstractPath is worth changing as I figure thousands of Path instances are created during normal operation of kie-wb. @porcelli WDYT?