### PR TITLE
[RHBPMS-4668] filter out invalid (null) login principals

### DIFF
--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/adapter/GroupAdapterAuthorizationSource.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/adapter/GroupAdapterAuthorizationSource.java
@@ -22,8 +22,10 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.security.auth.Subject;
 
 import org.jboss.errai.security.shared.api.Group;
@@ -40,25 +42,26 @@ public class GroupAdapterAuthorizationSource {
     protected List<String> loadEntitiesFromSubjectAndAdapters(String username,
                                                               Subject subject,
                                                               String[] rolePrincipleNames) {
-        List<String> roles = new ArrayList<String>();
+        List<String> roles = new ArrayList<>();
         try {
-
             List<String> principals = collectEntitiesFromSubject(username,
                                                                  subject,
                                                                  rolePrincipleNames);
-            if (principals != null && !principals.isEmpty()) {
-                roles.addAll(principals);
-            }
-
+            roles.addAll(filterValidPrincipals(principals));
             List<String> principalsFromAdapters = collectEntitiesFromAdapters(username,
                                                                               subject);
-            if (principalsFromAdapters != null && !principalsFromAdapters.isEmpty()) {
-                roles.addAll(principalsFromAdapters);
-            }
+            roles.addAll(filterValidPrincipals(principalsFromAdapters));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
         return roles;
+    }
+
+    private List<String> filterValidPrincipals(List<String> principals) {
+        if (principals == null) {
+            return new ArrayList<>();
+        }
+        return principals.stream().filter(Objects::nonNull).collect(Collectors.toList());
     }
 
     protected List<String> collectEntitiesFromAdapters(String username,

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/ServletSecurityAuthenticationServiceTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/ServletSecurityAuthenticationServiceTest.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.security.auth.Subject;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
@@ -98,7 +97,8 @@ public class ServletSecurityAuthenticationServiceTest {
         RoleRegistry.get().registerRole("role1");
         Set<Principal> principals = mockPrincipals("admin",
                                                    "role1",
-                                                   "group1");
+                                                   "group1",
+                                                   null);
         Subject subject = new Subject();
         subject.getPrincipals().addAll(principals);
         doReturn(subject).when(tested).getSubjectFromPolicyContext();


### PR DESCRIPTION
In some cases (like one the described in the JIRA), the list of
principals contained a principal with 'null' name, which is
probably wrong. This caused a NPE further down as the name was used
to compute hashcode. Filtering the invalid principals seems to be
the easiest way to workaround that issue.

This is my very best guess as what is going on in the JIRA (given it does not contain a reproducer nor a list of steps to reproduce)

@porcelli or @romartin could you please take a look?