### PR TITLE
[0.9.x][RHBPMS-4669] filter out invalid (null) login principals

### DIFF
--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/adapter/GroupAdapterAuthorizationSource.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/adapter/GroupAdapterAuthorizationSource.java
@@ -37,19 +37,26 @@ public class GroupAdapterAuthorizationSource {
         try {
 
             List<String> principals = collectEntitiesFromSubject( username, subject, rolePrincipleNames );
-            if ( principals != null && !principals.isEmpty() ) {
-                roles.addAll( principals );
-            }
+            roles.addAll( filterValidPrincipals( principals ) );
 
             List<String> principalsFromAdapters = collectEntitiesFromAdapters( username, subject );
-            if (principalsFromAdapters != null && !principalsFromAdapters.isEmpty()) {
-                roles.addAll( principalsFromAdapters );
-            }
-
+            roles.addAll( filterValidPrincipals(principalsFromAdapters ) );
         } catch ( Exception e ) {
             throw new RuntimeException( e );
         }
         return roles;
+    }
+
+    private List<String> filterValidPrincipals(List<String> principals) {
+        List<String> validPrincipals = new ArrayList<>();
+        if ( principals != null ) {
+            for (String principal : principals) {
+                if (principal != null) {
+                    validPrincipals.add(principal);
+                }
+            }
+        }
+        return validPrincipals;
     }
 
     protected List<String> collectEntitiesFromAdapters( String username,


### PR DESCRIPTION
In some cases (like one the described in the JIRA), the list of
principals contained a principal with 'null' name, which is
probably wrong. This caused a NPE further down as the name was used
to compute hashcode. Filtering the invalid principals seems to be
the easiest way to workaround that issue.

Backport of #707.