### PR TITLE
UF-517: Boostrap Selector CSS overriding Patternfly Selector CSS

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/resources/org/uberfire/client/views/static/uberfire-patternfly.css
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/resources/org/uberfire/client/views/static/uberfire-patternfly.css
@@ -338,3 +338,8 @@
 .uf-perspective-context-menu-empty {
     padding-top: 43px;
 }
+
+/*https://issues.jboss.org/browse/UF-517*/
+.bootstrap-select.btn-group .btn .caret {
+    margin-top: -4px !important;
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/UF-517

@cristianonicolai IDK if this is where/how we should override incompatibilities between BS + PF CSS?