### PR TITLE
[UF-523]  Preserve Workbench State on the URL

### DIFF
--- a/uberfire-api/src/main/java/org/uberfire/mvp/PlaceRequest.java
+++ b/uberfire-api/src/main/java/org/uberfire/mvp/PlaceRequest.java
@@ -59,6 +59,7 @@ public interface PlaceRequest {
      */
     boolean isUpdateLocationBarAllowed();
 
+    void setUpdateLocationBar(boolean updateLocationBar);
     /**
      * Returns the path associated with this {@link PlaceRequest}.
      */

--- a/uberfire-api/src/main/java/org/uberfire/mvp/impl/DefaultPlaceRequest.java
+++ b/uberfire-api/src/main/java/org/uberfire/mvp/impl/DefaultPlaceRequest.java
@@ -29,7 +29,7 @@ import org.uberfire.mvp.PlaceRequest;
 public class DefaultPlaceRequest implements PlaceRequest {
 
     protected final Map<String, String> parameters = new HashMap<String, String>();
-    private final boolean updateLocationBar;
+    private boolean updateLocationBar;
     protected String identifier;
 
     public DefaultPlaceRequest() {
@@ -239,6 +239,11 @@ public class DefaultPlaceRequest implements PlaceRequest {
     @Override
     public boolean isUpdateLocationBarAllowed() {
         return updateLocationBar;
+    }
+
+    @Override
+    public void setUpdateLocationBar(boolean updateLocationBar) {
+        this.updateLocationBar = updateLocationBar;
     }
 
     @Override

--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/UberfireDocksImpl.java
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/UberfireDocksImpl.java
@@ -27,8 +27,10 @@ import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.GWT;
 import org.uberfire.client.docks.view.DocksBar;
 import org.uberfire.client.docks.view.DocksBars;
+import org.uberfire.client.mvp.PlaceHistoryHandler;
 import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.client.workbench.docks.UberfireDockContainerReadyEvent;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;

--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/DocksBars.java
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/DocksBars.java
@@ -22,6 +22,7 @@ import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.ui.Widget;
 import org.uberfire.client.docks.view.bars.DocksCollapsedBar;
@@ -29,6 +30,7 @@ import org.uberfire.client.docks.view.bars.DocksExpandedBar;
 import org.uberfire.client.docks.view.menu.MenuBuilder;
 import org.uberfire.client.mvp.AbstractWorkbenchScreenActivity;
 import org.uberfire.client.mvp.Activity;
+import org.uberfire.client.mvp.PlaceHistoryHandler;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.client.workbench.docks.UberfireDockPosition;
@@ -47,16 +49,19 @@ public class DocksBars {
     private Event<UberfireDocksInteractionEvent> dockInteractionEvent;
     private UberfireDocksContainer uberfireDocksContainer;
     private List<DocksBar> docks = new ArrayList<>();
+    private PlaceHistoryHandler placeHistoryHandler;
 
     @Inject
     public DocksBars(PlaceManager placeManager,
                      MenuBuilder menuBuilder,
                      Event<UberfireDocksInteractionEvent> dockInteractionEvent,
-                     UberfireDocksContainer uberfireDocksContainer) {
+                     UberfireDocksContainer uberfireDocksContainer,
+                     PlaceHistoryHandler placeHistoryHandler) {
         this.placeManager = placeManager;
         this.menuBuilder = menuBuilder;
         this.dockInteractionEvent = dockInteractionEvent;
         this.uberfireDocksContainer = uberfireDocksContainer;
+        this.placeHistoryHandler = placeHistoryHandler;
     }
 
     public void setup() {
@@ -219,11 +224,18 @@ public class DocksBars {
                          docksBar,
                          expandedBar);
         expand(docksBar.getDockResizeBar());
-        placeManager.goTo(placeRequest,
-                          expandedBar.targetPanel());
+        goToPlace(expandedBar,
+                  placeRequest);
 
         lookUpContextMenus(placeRequest,
                            docksBar.getExpandedBar());
+    }
+
+    private void goToPlace(DocksExpandedBar expandedBar,
+                           PlaceRequest placeRequest) {
+        placeRequest.setUpdateLocationBar(false);
+        placeManager.goTo(placeRequest,
+                          expandedBar.targetPanel());
     }
 
     private void lookUpContextMenus(PlaceRequest placeRequest,
@@ -267,7 +279,6 @@ public class DocksBars {
                         expand(docksBar.getCollapsedBar());
                     }
                     uberfireDocksContainer.resize();
-                    ;
                     dockInteractionEvent.fire(new UberfireDocksInteractionEvent(targetDock,
                                                                                 UberfireDocksInteractionEvent.InteractionType.DESELECTED));
                 }

--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/view/DocksBarsTest.java
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/view/DocksBarsTest.java
@@ -67,7 +67,8 @@ public class DocksBarsTest {
         docksBars = new DocksBars(placeManager,
                                   menuBuilder,
                                   dockInteractionEvent,
-                                  uberfireDocksContainer);
+                                  uberfireDocksContainer,
+                                  null);
     }
 
     @Test

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/BookmarkableUrlHelper.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/BookmarkableUrlHelper.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.mvp;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.uberfire.client.workbench.docks.UberfireDock;
+import org.uberfire.mvp.PlaceRequest;
+
+/**
+ * A bookmarkable URL has the following form:
+ * <p>
+ * http://url/index.html#FWidgets|$PagedTableScreen[WSimpleDockScreen,],~WiresPropertiesScreen$PagedTableScreen
+ * <p>
+ * between the '#' and '|' there is the perspective name
+ * between the '|' and '$' there is the CSV list of the screens opened when loading the perspective
+ * between the '[' and ']'there is the CSV list of the docked Screens
+ * after the '$' there is the CSV list of the screens not belonging to the current perspective
+ * <p>
+ * '~' denotes a closed screen
+ * <p>
+ * In this unit we have the basic methods used to compose such URLs
+ */
+public class BookmarkableUrlHelper {
+
+    public final static String PERSPECTIVE_SEP = "|";
+    public final static String DOCK_BEGIN_SEP = "[";
+    public final static String DOCK_CLOSE_SEP = "]";
+    public final static String SEPARATOR = ",";
+    public final static String OTHER_SCREEN_SEP = "$";
+    public final static String CLOSED_PREFIX = "~";
+    public final static String CLOSED_DOCK_PREFIX = "!";
+    public final static int MAX_NAV_URL_SIZE = 1900;
+
+    private static boolean isNotBlank(final String str) {
+        return (str != null
+                && str.trim().length() > 0);
+    }
+
+    private static boolean isNotBlank(final PlaceRequest place) {
+        return (null != place && isNotBlank(place.getFullIdentifier()));
+    }
+
+    /**
+     * Add a screen to the bookmarkable URL. If the screen belongs to the currently opened
+     * perspective we add it to the list between the '|' and '$', otherwise we add it
+     * after the '$'.
+     * <p>
+     * We add the '|' or the '$' when needed
+     * @param bookmarkableUrl
+     * @param placeRequest
+     * @return
+     */
+    public static String registerOpenedScreen(String bookmarkableUrl,
+                                              final PlaceRequest placeRequest) {
+        final String screenName = placeRequest.getFullIdentifier();
+        final String closedScreen = CLOSED_PREFIX.concat(screenName);
+        final String currentBookmarkableUrl = bookmarkableUrl;
+
+        if (screenWasClosed(bookmarkableUrl,
+                            closedScreen)) {
+            bookmarkableUrl = bookmarkableUrl.replace(closedScreen,
+                                                      screenName);
+        } else if (!isPerspectiveInUrl(bookmarkableUrl)) {
+            // must add the screen in the group of the current perspective (which is not yet loaded)
+            if (isNotBlank(bookmarkableUrl)) {
+                bookmarkableUrl = bookmarkableUrl.concat(SEPARATOR).concat(screenName);
+            } else {
+                bookmarkableUrl = screenName;
+            }
+        } else {
+            // this is a screen outside the current perspective
+            if (!urlContainsExtraPerspectiveScreen(bookmarkableUrl)) {
+                bookmarkableUrl = bookmarkableUrl.concat(OTHER_SCREEN_SEP).concat(screenName);
+            } else {
+                bookmarkableUrl = bookmarkableUrl.concat(SEPARATOR).concat(screenName);
+            }
+        }
+        if (isBiggerThenMaxURLSize(bookmarkableUrl)) {
+            return currentBookmarkableUrl;
+        }
+        return bookmarkableUrl;
+    }
+
+    private static boolean screenWasClosed(String bookmarkableUrl,
+                                           String closedScreen) {
+        return bookmarkableUrl.indexOf(closedScreen) != -1;
+    }
+
+    private static boolean isBiggerThenMaxURLSize(String bookmarkableUrl) {
+        return isNotBlank(bookmarkableUrl) &&
+                bookmarkableUrl.length() >= MAX_NAV_URL_SIZE;
+    }
+
+    /**
+     * Update the bookmarkable URL, marking a screen or editor closed. Basically if the screen belongs
+     * to the currently opened perspective the we prefix the screen with a '~'; if the
+     * screen doesn't belong to the current perspective, that is, after the '$', the it
+     * is simply removed.
+     * <p>
+     * We remove the '$' when needed
+     * @param screenName
+     */
+    public static String registerClose(String bookmarkableUrl,
+                                       final String screenName) {
+        final boolean isPerspective = isPerspectiveScreen(bookmarkableUrl,
+                                                          screenName);
+        final String separator = isPerspective ? PERSPECTIVE_SEP : OTHER_SCREEN_SEP;
+        final String closedScreen = CLOSED_PREFIX.concat(screenName);
+        final String uniqueScreenAfterDelimiter =
+                separator.concat(screenName); // |screen or $screen
+        final String firstScreenAfterDelimiter =
+                uniqueScreenAfterDelimiter.concat(SEPARATOR); // |screen, or $screen,
+        final String commaSeparatedScreen =
+                screenName.concat(SEPARATOR); // screen,
+
+        if (isScreenClosed(bookmarkableUrl,
+                           closedScreen)) {
+            return bookmarkableUrl;
+        }
+        if (isPerspective) {
+            bookmarkableUrl = bookmarkableUrl.replace(screenName,
+                                                      closedScreen);
+        } else {
+            if (bookmarkableUrl.contains(firstScreenAfterDelimiter)) {
+                bookmarkableUrl = bookmarkableUrl.replace(firstScreenAfterDelimiter,
+                                                          separator);
+            } else if (bookmarkableUrl.contains(uniqueScreenAfterDelimiter)) {
+                bookmarkableUrl = bookmarkableUrl.replace(uniqueScreenAfterDelimiter,
+                                                          "");
+            } else if (bookmarkableUrl.contains(commaSeparatedScreen)) {
+                bookmarkableUrl = bookmarkableUrl.replace(commaSeparatedScreen,
+                                                          "");
+            }
+        }
+        return bookmarkableUrl;
+    }
+
+    /**
+     * Given a bookmarkable URL this methods returns a PlaceRequest
+     * with the perspective
+     * @param place\
+     * @return
+     */
+    public static PlaceRequest getPerspectiveFromPlace(PlaceRequest place) {
+        String url = place.getFullIdentifier();
+
+        if (isPerspectiveInUrl(url)) {
+            String perspectiveName = url.substring(0,
+                                                   url.indexOf(PERSPECTIVE_SEP));
+            PlaceRequest copy = place.clone();
+            copy.setIdentifier(perspectiveName);
+            if (!place.getParameters().isEmpty()) {
+                for (Map.Entry<String, String> elem : place.getParameters().entrySet()) {
+                    copy.addParameter(elem.getKey(),
+                                      elem.getValue());
+                }
+            }
+            return copy;
+        }
+        return place;
+    }
+
+    /**
+     * Check whether the screen belongs to the currently opened perspective
+     * @param screen
+     * @return
+     */
+    public static boolean isPerspectiveScreen(final String bookmarkableUrl,
+                                              final String screen) {
+        return (isNotBlank(screen)
+                && isNotBlank(bookmarkableUrl)
+                && (!urlContainsExtraPerspectiveScreen(bookmarkableUrl)
+                || (bookmarkableUrl.indexOf(OTHER_SCREEN_SEP) > bookmarkableUrl.indexOf(screen))));
+    }
+
+    /**
+     * Returns true if the perspective is present in the URL
+     * @return
+     */
+    public static boolean isPerspectiveInUrl(final String url) {
+        return (isNotBlank(url) && (url.indexOf(PERSPECTIVE_SEP) > 0));
+    }
+
+    /**
+     * Check if the URL contains screens not belonging to the current perspective
+     * @return
+     */
+    public static boolean urlContainsExtraPerspectiveScreen(final String bookmarkableUrl) {
+        return (bookmarkableUrl.indexOf(OTHER_SCREEN_SEP) != -1);
+    }
+
+    /**
+     * Given a screen name, this method extracts the corresponding token in the
+     * URL, that is the screen name with optional parameters and markers
+     * @param screen
+     * @return
+     */
+    public static String getUrlToken(final String bookmarkableUrl,
+                                     final String screen) {
+        int st = isPerspectiveInUrl(bookmarkableUrl) ? (bookmarkableUrl.indexOf(PERSPECTIVE_SEP) + 1) : 0;
+        String screensList = bookmarkableUrl.replace(OTHER_SCREEN_SEP,
+                                                     SEPARATOR)
+                .substring(st,
+                           bookmarkableUrl.length());
+
+        String tokens[] = screensList.split(SEPARATOR);
+        Optional<String> token = Arrays.asList(tokens).stream()
+                .filter(s -> s.contains(screen))
+                .findFirst();
+
+        return token.orElse(screen);
+    }
+
+    /**
+     * Return the docked screens in the URL
+     * @param url
+     * @return
+     */
+    public static Set<String> getDockedScreensFromUrl(final String url) {
+        int start;
+        int end;
+        String docks;
+
+        if (!isNotBlank(url)) {
+            return new HashSet<>();
+        }
+        start = url.indexOf(DOCK_BEGIN_SEP) + 1;
+        end = url.indexOf(DOCK_CLOSE_SEP) - 1;
+
+        if (start > 0) {
+            docks = url.substring(start,
+                                  end);
+            String[] token = docks.split(SEPARATOR);
+            return new HashSet<>(Arrays.asList(token));
+        }
+        return new HashSet<>();
+    }
+
+    /**
+     * Return all the docked screens
+     * @param place
+     * @return
+     * @note non-docked screens are not taken into consideration
+     */
+    public static Set<String> getDockedScreensFromPlace(final PlaceRequest place) {
+        if (null != place) {
+            return getDockedScreensFromUrl(place.getFullIdentifier());
+        }
+        return new HashSet<>();
+    }
+
+    /**
+     * Return all the screens (opened or closed) that is, everything
+     * after the perspective declaration
+     * @param place
+     * @return
+     * @note docked screens are not taken into consideration
+     */
+    public static Set<String> getScreensFromPlace(final PlaceRequest place) {
+        String url;
+        int start;
+        int end;
+        String docks;
+
+        if (!isNotBlank(place)) {
+            return new HashSet<>();
+        }
+        // get everything after the perspective
+        if (isPerspectiveInUrl(place.getFullIdentifier())) {
+            String request = place.getFullIdentifier();
+
+            url = request.substring(request.indexOf(PERSPECTIVE_SEP) + 1);
+        } else {
+            url = place.getFullIdentifier();
+        }
+
+        start = url.indexOf(DOCK_BEGIN_SEP);
+        end = url.indexOf(DOCK_CLOSE_SEP) + 1;
+        if (start > 0) {
+            docks = url.substring(start,
+                                  end);
+            url = url.replace(docks,
+                              "");
+        }
+        // replace the '$' with a comma ','
+        url = url.replace(OTHER_SCREEN_SEP,
+                          SEPARATOR);
+        String[] token = url.split(SEPARATOR);
+        return new HashSet<>(Arrays.asList(token));
+    }
+
+    /**
+     * Get the opened screens in the given place request
+     * @param place
+     * @return
+     */
+    public static Set<String> getClosedScreenFromPlace(final PlaceRequest place) {
+        Set<String> screens = getScreensFromPlace(place);
+        Set<String> result = screens.stream()
+                .filter(s -> s.startsWith(CLOSED_PREFIX))
+                .collect(Collectors.toSet());
+        return result;
+    }
+
+    /**
+     * Get the opened screens in the given place request
+     * @param place
+     * @return
+     */
+    public static Set<String> getOpenedScreenFromPlace(final PlaceRequest place) {
+        Set<String> screens = getScreensFromPlace(place);
+        Set<String> result = screens.stream()
+                .filter(s -> !s.startsWith(CLOSED_PREFIX))
+                .collect(Collectors.toSet());
+        return result;
+    }
+
+    /**
+     * Return true if the given screen is already closed.
+     * @param screen
+     * @return
+     * @note docked screens are ignored
+     */
+    public static boolean isScreenClosed(final String bookmarkableUrl,
+                                         String screen) {
+        if (!screen.startsWith(CLOSED_PREFIX)) {
+            screen = CLOSED_PREFIX.concat(screen);
+        }
+        return (bookmarkableUrl.indexOf(screen) != -1);
+    }
+
+    public static String registerOpenedPerspective(String currentBookmarkableURLStatus,
+                                                   PlaceRequest place) {
+        return place.getFullIdentifier().concat(PERSPECTIVE_SEP).concat(currentBookmarkableURLStatus);
+    }
+
+    private static String getDockId(UberfireDock targetDock) {
+        return targetDock.getDockPosition().getShortName()
+                + targetDock.getPlaceRequest().getFullIdentifier() + SEPARATOR;
+    }
+
+    public static String registerOpenedDock(String currentBookmarkableURLStatus,
+                                            UberfireDock targetDock) {
+        if (!isNotBlank(currentBookmarkableURLStatus)
+                || null == targetDock) {
+            return currentBookmarkableURLStatus;
+        }
+        final String id = getDockId(targetDock);
+        final String closed = CLOSED_DOCK_PREFIX.concat(id);
+
+        if (currentBookmarkableURLStatus.contains(DOCK_CLOSE_SEP)) {
+            String result = null;
+
+            if (!currentBookmarkableURLStatus.contains(id)) {
+                // the screen is not in the URL, insert in last position
+                result = currentBookmarkableURLStatus.replace(DOCK_CLOSE_SEP,
+                                                              (id + DOCK_CLOSE_SEP));
+            } else if (currentBookmarkableURLStatus.contains(closed)) {
+                // the screen is closed
+                result = currentBookmarkableURLStatus.replace(closed,
+                                                              id);
+            } else {
+                // screen already in URL
+                result = currentBookmarkableURLStatus;
+            }
+            return result;
+        } else {
+            return currentBookmarkableURLStatus + DOCK_BEGIN_SEP + (getDockId(targetDock) + DOCK_CLOSE_SEP);
+        }
+    }
+
+    public static String registerClosedDock(String currentBookmarkableURLStatus,
+                                            UberfireDock targetDock) {
+        if (!isNotBlank(currentBookmarkableURLStatus)
+                || null == targetDock) {
+            return currentBookmarkableURLStatus;
+        }
+        final String id = getDockId(targetDock);
+        final String closed = CLOSED_DOCK_PREFIX.concat(id);
+        if (!currentBookmarkableURLStatus.contains(closed)) {
+            return currentBookmarkableURLStatus.replace(id,
+                                                        CLOSED_DOCK_PREFIX.concat(id));
+        }
+        return currentBookmarkableURLStatus;
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/docks/UberfireDockPosition.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/docks/UberfireDockPosition.java
@@ -23,11 +23,20 @@ public enum UberfireDockPosition {
         public boolean allowSingleDockItem() {
             return false;
         }
+        @Override
+        public String getShortName() {
+            return "S";
+        }
     },
     WEST {
         @Override
         public boolean allowSingleDockItem() {
             return true;
+        }
+
+        @Override
+        public String getShortName() {
+            return "W";
         }
     },
     EAST {
@@ -35,7 +44,12 @@ public enum UberfireDockPosition {
         public boolean allowSingleDockItem() {
             return false;
         }
+        @Override
+        public String getShortName() {
+            return "E";
+        }
     };
 
     public abstract boolean allowSingleDockItem();
+    public abstract String getShortName();
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/docks/UberfireDocks.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/docks/UberfireDocks.java
@@ -36,4 +36,5 @@ public interface UberfireDocks {
 
     void enable(UberfireDockPosition position,
                 String perspectiveName);
+
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/BookmarkableUrlHelperTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/BookmarkableUrlHelperTest.java
@@ -1,0 +1,587 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.mvp;
+
+import java.util.Set;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.uberfire.client.workbench.docks.UberfireDock;
+import org.uberfire.client.workbench.docks.UberfireDockPosition;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
+
+public class BookmarkableUrlHelperTest extends TestCase {
+
+    @Test
+    public void testRegisterOpen() {
+        PlaceRequest req1 = new DefaultPlaceRequest("screen1");
+        PlaceRequest req2 = new DefaultPlaceRequest("screen2");
+        PlaceRequest req3 = new DefaultPlaceRequest("screen3");
+        PlaceRequest req4 = new DefaultPlaceRequest("screen4");
+        final String perspective = "perspective";
+        String url = "";
+
+        url = BookmarkableUrlHelper.registerOpenedScreen(url,
+                                                         req1);
+        assertEquals(req1.getFullIdentifier(),
+                     url);
+        url = BookmarkableUrlHelper.registerOpenedScreen(url,
+                                                         req2);
+        assertEquals("screen1,screen2",
+                     url);
+
+        // add the perspective, want to test screen not belonging to the current perspective
+        url = perspective.concat(BookmarkableUrlHelper.PERSPECTIVE_SEP)
+                .concat(url);
+        url = BookmarkableUrlHelper.registerOpenedScreen(url,
+                                                         req3);
+
+        assertEquals("perspective|screen1,screen2$screen3",
+                     url);
+
+        url = BookmarkableUrlHelper.registerOpenedScreen(url,
+                                                         req4);
+        assertEquals("perspective|screen1,screen2$screen3,screen4",
+                     url);
+
+        // test with screen closed (we compose the URL)
+        final String closedScreen = "closedScreen";
+        final PlaceRequest closed = new DefaultPlaceRequest(closedScreen);
+        url = "perspective|"
+                .concat(BookmarkableUrlHelper.CLOSED_PREFIX)
+                .concat(closedScreen).concat(",openScreen$externalScreen");
+        url = BookmarkableUrlHelper.registerOpenedScreen(url,
+                                                         closed);
+        String expected = "perspective|"
+                .concat(closedScreen).concat(",openScreen$externalScreen");
+        assertEquals(expected,
+                     url);
+        // compose a big URL
+        StringBuilder bigUrl = new StringBuilder(perspective);
+        while (bigUrl.length() < BookmarkableUrlHelper.MAX_NAV_URL_SIZE) {
+            bigUrl.append(",screen");
+        }
+        url = BookmarkableUrlHelper.registerOpenedScreen(bigUrl.toString(),
+                                                         req1);
+        assertNotNull(url);
+        assertEquals(bigUrl.toString(),
+                     url);
+    }
+
+    @Test
+    public void testRegisterClose() {
+        String url = "perspective|screen1,screen2$screen3,screen4";
+
+        // close screens not belonging to the current perspective
+        url = BookmarkableUrlHelper.registerClose(url,
+                                                  "screen3");
+        assertEquals("perspective|screen1,screen2$screen4",
+                     url);
+        url = BookmarkableUrlHelper.registerClose(url,
+                                                  "screen4");
+        assertEquals("perspective|screen1,screen2",
+                     url);
+
+        // close screens belonging to the current perspective
+
+        url = BookmarkableUrlHelper.registerClose(url,
+                                                  "screen1");
+        assertEquals("perspective|~screen1,screen2",
+                     url);
+
+        url = BookmarkableUrlHelper.registerClose(url,
+                                                  "screen2");
+        assertEquals("perspective|~screen1,~screen2",
+                     url);
+
+        // screen already closed
+        url = "perspective|screen1,~screen2$screen3";
+        url = BookmarkableUrlHelper.registerClose(url,
+                                                  "screen2");
+        assertEquals("perspective|screen1,~screen2$screen3",
+                     url);
+
+        url = "perspective|screen1$screen2";
+        url = BookmarkableUrlHelper.registerClose(url,
+                                                  "screen2");
+        assertEquals("perspective|screen1",
+                     url);
+
+        url = "perspective|screen1$screen2,screen3";
+        url = BookmarkableUrlHelper.registerClose(url,
+                                                  "screen2");
+        assertEquals("perspective|screen1$screen3",
+                     url);
+
+        url = "perspective|screen1$screen2,screen3,screen4";
+        url = BookmarkableUrlHelper.registerClose(url,
+                                                  "screen3");
+        assertEquals("perspective|screen1$screen2,screen4",
+                     url);
+    }
+
+    @Test
+    public void testGetPerspectiveFromPlace() {
+        final String perspectiveName = "eccePerspective";
+        final String bookmarkableUrl = perspectiveName
+                .concat("|~screen1,~screen2");
+        final PlaceRequest req = new DefaultPlaceRequest(bookmarkableUrl);
+
+        PlaceRequest place = BookmarkableUrlHelper.getPerspectiveFromPlace(req);
+
+        assertNotNull(place);
+        assertNotSame(req,
+                      place);
+        assertEquals(perspectiveName,
+                     place.getFullIdentifier());
+
+        // return the same object if no perspective in URL
+        final PlaceRequest empty = new DefaultPlaceRequest("screenOpened,~screenClosed");
+        empty.addParameter("param",
+                           "value");
+        place = BookmarkableUrlHelper.getPerspectiveFromPlace(empty);
+        assertNotNull(place);
+        assertEquals(empty.getFullIdentifier(),
+                     place.getFullIdentifier());
+    }
+
+    @Test
+    public void testGetPerspectiveFromPlaceWithParams() {
+        final String perspectiveName = "eccePerspective";
+        final String bookmarkableUrl = perspectiveName
+                .concat("|~screen1,~screen2");
+        final PlaceRequest req = new DefaultPlaceRequest(bookmarkableUrl);
+
+        req.addParameter("param",
+                         "value");
+        PlaceRequest place = BookmarkableUrlHelper.getPerspectiveFromPlace(req);
+
+        assertNotNull(place);
+        assertNotSame(req,
+                      place);
+        StringBuilder expected = new StringBuilder(perspectiveName);
+        expected.append("?param=value");
+        assertEquals(expected.toString(),
+                     place.getFullIdentifier());
+    }
+
+    @Test
+    public void testIsPerspectiveScreen() {
+        final String url = "perspective|screen1,screen2$screen3,screen4";
+
+        assertTrue(BookmarkableUrlHelper.isPerspectiveScreen(url,
+                                                             "screen1"));
+        assertTrue(BookmarkableUrlHelper.isPerspectiveScreen(url,
+                                                             "screen2"));
+        assertFalse(BookmarkableUrlHelper.isPerspectiveScreen(url,
+                                                              "screen3"));
+        assertFalse(BookmarkableUrlHelper.isPerspectiveScreen(url,
+                                                              "screen4"));
+        assertFalse(BookmarkableUrlHelper.isPerspectiveScreen(null,
+                                                              "screen2"));
+        assertFalse(BookmarkableUrlHelper.isPerspectiveScreen("",
+                                                              "screen2"));
+        assertFalse(BookmarkableUrlHelper.isPerspectiveScreen(url,
+                                                              null));
+    }
+
+    @Test
+    public void testIsPerspectiveInUrl() {
+        final String url1 = "perspective|screen1,screen2$screen3,screen4";
+        final String url2 = "screen1,screen2";
+        final String url3 = "perspective|screen1,screen2$screen3,screen4";
+
+        assertTrue(BookmarkableUrlHelper.isPerspectiveInUrl(url1));
+        assertFalse(BookmarkableUrlHelper.isPerspectiveInUrl(url2));
+        assertTrue(BookmarkableUrlHelper.isPerspectiveInUrl(url3));
+    }
+
+    @Test
+    public void testUrlContainsExtraPerspectiveScreen() {
+        final String url1 = "perspective|screen1,screen2$screen3,screen4";
+        final String url2 = "screen1,screen2";
+        final String url3 = "perspective|screen1,screen2$screen3,screen4";
+
+        assertTrue(BookmarkableUrlHelper.urlContainsExtraPerspectiveScreen(url1));
+        assertFalse(BookmarkableUrlHelper.urlContainsExtraPerspectiveScreen(url2));
+        assertTrue(BookmarkableUrlHelper.urlContainsExtraPerspectiveScreen(url3));
+    }
+
+    @Test
+    public void testGetUrlInToken() {
+        final String url1 = "perspective|#screen1,§screen2$#screen3,!screen4";
+        final String url2 = "!screen1,#screen2";
+
+        assertEquals("!screen1",
+                     BookmarkableUrlHelper.getUrlToken(url2,
+                                                       "screen1"));
+        assertEquals("#screen2",
+                     BookmarkableUrlHelper.getUrlToken(url2,
+                                                       "screen2"));
+
+        assertEquals("§screen2",
+                     BookmarkableUrlHelper.getUrlToken(url1,
+                                                       "screen2"));
+        assertEquals("#screen1",
+                     BookmarkableUrlHelper.getUrlToken(url1,
+                                                       "screen1"));
+        assertEquals("#screen3",
+                     BookmarkableUrlHelper.getUrlToken(url1,
+                                                       "screen3"));
+        assertEquals("!screen4",
+                     BookmarkableUrlHelper.getUrlToken(url1,
+                                                       "screen4"));
+    }
+
+    @Test
+    public void testGetScreensFromPlace() {
+        final String url = "perspective|~screen1,screen2$!screen3,screen4";
+        final String url2 = "UFWidgets|PagedTableScreen[ESimpleDockScreen,!WSimpleDockScreen,ESimpleDockScreen,]";
+        final String url3 = "PagedTableScreen[ESimpleDockScreen,!WSimpleDockScreen,ESimpleDockScreen,]";
+        final PlaceRequest place = new DefaultPlaceRequest(url);
+        final PlaceRequest place2 = new DefaultPlaceRequest(url2);
+        final PlaceRequest placeNoPerspective = new DefaultPlaceRequest(url3);
+        final PlaceRequest placeNull = null;
+
+        Set<String> set = BookmarkableUrlHelper.getScreensFromPlace(place);
+        assertNotNull(set);
+        assertFalse(set.isEmpty());
+
+        assertEquals(4,
+                     set.size());
+        assertTrue(set.contains("~screen1"));
+        assertTrue(set.contains("screen2"));
+        assertTrue(set.contains("!screen3"));
+        assertTrue(set.contains("screen4"));
+
+        set = BookmarkableUrlHelper.getScreensFromPlace(place2);
+        assertNotNull(set);
+
+        assertFalse(set.isEmpty());
+        assertEquals(1,
+                     set.size());
+        assertTrue(set.contains("PagedTableScreen"));
+
+        set = BookmarkableUrlHelper.getScreensFromPlace(placeNull);
+        assertNotNull(set);
+        assertTrue(set.isEmpty());
+
+        // test with bookmarkable URL with no perspective
+        set = BookmarkableUrlHelper.getScreensFromPlace(placeNoPerspective);
+        assertNotNull(set);
+        assertFalse(set.isEmpty());
+        assertTrue(set.contains("PagedTableScreen"));
+    }
+
+    @Test
+    public void testGetClosedScreenFromPlace() {
+        final String url = "perspective|~screen1,screen2$~screen3,screen4";
+        final String url2 = "UFWidgets|PagedTableScreen[ESimpleDockScreen,!WSimpleDockScreen,ESimpleDockScreen,]";
+        final PlaceRequest place = new DefaultPlaceRequest(url);
+        final PlaceRequest place2 = new DefaultPlaceRequest(url2);
+
+        Set<String> set = BookmarkableUrlHelper.getClosedScreenFromPlace(place);
+        assertNotNull(set);
+        assertFalse(set.isEmpty());
+        assertEquals(2,
+                     set.size());
+        assertTrue(set.contains("~screen1"));
+        assertTrue(set.contains("~screen3"));
+
+        set = BookmarkableUrlHelper.getClosedScreenFromPlace(place2);
+        assertNotNull(set);
+        assertTrue(set.isEmpty());
+    }
+
+    @Test
+    public void testGetOpenedScreenFromPlace() {
+        final String url = "perspective|~screen1,screen2$~screen3,screen4";
+        final String url2 = "UFWidgets|PagedTableScreen[ESimpleDockScreen,!WSimpleDockScreen,ESimpleDockScreen,]";
+        final PlaceRequest place = new DefaultPlaceRequest(url);
+        final PlaceRequest place2 = new DefaultPlaceRequest(url2);
+
+        Set<String> set = BookmarkableUrlHelper.getOpenedScreenFromPlace(place);
+        assertNotNull(set);
+        assertFalse(set.isEmpty());
+        assertTrue(set.contains("screen2"));
+        assertTrue(set.contains("screen4"));
+
+        set = BookmarkableUrlHelper.getOpenedScreenFromPlace(place2);
+        assertNotNull(set);
+        assertFalse(set.isEmpty());
+        assertTrue(set.contains("PagedTableScreen"));
+    }
+
+    @Test
+    public void testGDockedScreensFromPlace() {
+        final String url = "perspective|~screen1,screen2$~screen3,screen4";
+        final String url2 = "UFWidgets|PagedTableScreen[ESimpleDockScreen,!WSimpleDockScreen,ESimpleDockScreen,]";
+        final PlaceRequest place = new DefaultPlaceRequest(url);
+        final PlaceRequest place2 = new DefaultPlaceRequest(url2);
+
+        Set<String> set = BookmarkableUrlHelper.getDockedScreensFromPlace(place);
+        assertNotNull(set);
+        assertTrue(set.isEmpty());
+
+        set = BookmarkableUrlHelper.getDockedScreensFromPlace(place2);
+        assertNotNull(set);
+        assertFalse(set.isEmpty());
+        assertEquals(2,
+                     set.size());
+        assertTrue(set.contains("ESimpleDockScreen"));
+        assertTrue(set.contains("!WSimpleDockScreen"));
+
+        // test with invalid URL
+        set = BookmarkableUrlHelper.getDockedScreensFromPlace(null);
+        assertNotNull(set);
+        assertTrue(set.isEmpty());
+    }
+
+    @Test
+    public void testGDockedScreensFromPlaceString() {
+        final String url = "perspective|~screen1,screen2$~screen3,screen4";
+        final String url2 = "UFWidgets|PagedTableScreen[ESimpleDockScreen,!WSimpleDockScreen,EAnotherDockScreen,]";
+
+        Set<String> set = BookmarkableUrlHelper.getDockedScreensFromUrl(url);
+        assertNotNull(set);
+        assertTrue(set.isEmpty());
+
+        set = BookmarkableUrlHelper.getDockedScreensFromUrl(url2);
+        assertNotNull(set);
+        assertFalse(set.isEmpty());
+        assertEquals(3,
+                     set.size());
+        assertTrue(set.contains("ESimpleDockScreen"));
+        assertTrue(set.contains("!WSimpleDockScreen"));
+        assertTrue(set.contains("EAnotherDockScreen"));
+
+        // test with invalid URL
+        set = BookmarkableUrlHelper.getDockedScreensFromUrl(null);
+        assertNotNull(set);
+        assertTrue(set.isEmpty());
+    }
+
+    @Test
+    public void testIsScreenClosed() {
+        final String url = "perspective|~screen1,screen2$~screen3,screen4";
+        final String url2 = "UFWidgets|PagedTableScreen[ESimpleDockScreen,!WSimpleDockScreen,ESimpleDockScreen,]";
+
+        assertTrue(BookmarkableUrlHelper.isScreenClosed(
+                url,
+                "screen1"));
+        assertTrue(BookmarkableUrlHelper.isScreenClosed(
+                url,
+                "screen3"));
+        assertFalse(BookmarkableUrlHelper.isScreenClosed(
+                url,
+                "screen2"));
+        assertFalse(BookmarkableUrlHelper.isScreenClosed(
+                url,
+                "screen4"));
+
+        // docked screens are ignored
+        assertFalse(BookmarkableUrlHelper.isScreenClosed(
+                url2,
+                "PagedTableScreen"));
+        assertFalse(BookmarkableUrlHelper.isScreenClosed(
+                url2,
+                "ESimpleDockScreen"));
+        assertFalse(BookmarkableUrlHelper.isScreenClosed(
+                url2,
+                "ESimpleDockScreen"));
+        assertFalse(BookmarkableUrlHelper.isScreenClosed(
+                url2,
+                "!WSimpleDockScreen"));
+    }
+
+    @Test
+    public void testRegisterOpenedPerspective() {
+        final String screens = "screen1,~screen2";
+        final String perspective = "perspective";
+        final PlaceRequest place = new DefaultPlaceRequest(perspective);
+        String url = screens;
+
+        url = BookmarkableUrlHelper.registerOpenedPerspective(url,
+                                                              place);
+
+        assertEquals(perspective.concat(BookmarkableUrlHelper.PERSPECTIVE_SEP).concat(screens),
+                     url);
+    }
+
+    @Test
+    public void testRegisterOpenDock() {
+        final String screens = "screen1";
+        final String dockName = "dockedScreen";
+        final String perspectiveName = "perspectiveName";
+        String url = perspectiveName
+                .concat(BookmarkableUrlHelper.PERSPECTIVE_SEP)
+                .concat(screens);
+        final UberfireDock dock1 = createUberfireDockForTest(dockName,
+                                                             perspectiveName);
+        final UberfireDock dock2 = createUberfireDockForTest(dockName.concat("New"),
+                                                             perspectiveName);
+
+        url = BookmarkableUrlHelper.registerOpenedDock(url,
+                                                       dock1);
+        assertEquals(perspectiveName
+                             .concat(BookmarkableUrlHelper.PERSPECTIVE_SEP)
+                             .concat("screen1[WdockedScreen,]"),
+                     url);
+        url = BookmarkableUrlHelper.registerOpenedDock(url,
+                                                       dock2);
+        assertEquals(perspectiveName
+                             .concat(BookmarkableUrlHelper.PERSPECTIVE_SEP)
+                             .concat("screen1[WdockedScreen,WdockedScreenNew,]"),
+                     url);
+
+        // test with a closed dock
+        url = perspectiveName
+                .concat(BookmarkableUrlHelper.PERSPECTIVE_SEP)
+                .concat("screen1[!WdockedScreen,]");
+        String expected = perspectiveName
+                .concat(BookmarkableUrlHelper.PERSPECTIVE_SEP)
+                .concat("screen1[WdockedScreen,]");
+        url = BookmarkableUrlHelper.registerOpenedDock(url,
+                                                       dock1);
+        assertEquals(expected, url);
+
+        // test with invalid dock and URL
+        expected = BookmarkableUrlHelper.registerOpenedDock(url,
+                                                                   null);
+        assertNotNull(expected);
+        assertEquals(expected, url);
+
+        url = "  ";
+        expected = BookmarkableUrlHelper.registerOpenedDock(url,
+                                                            null);
+        assertNotNull(expected);
+        assertEquals(expected, url);
+    }
+
+    @Test
+    public void testDoubleRegisterOpenDock() {
+        final String screens = "screen1";
+        final String dockName = "dockedScreen";
+        final String perspectiveName = "perspectiveName";
+        String url = perspectiveName
+                .concat(BookmarkableUrlHelper.PERSPECTIVE_SEP)
+                .concat(screens);
+        final UberfireDock dock1 = createUberfireDockForTest(dockName,
+                                                             perspectiveName);
+        final UberfireDock dock2 = createUberfireDockForTest(dockName.concat("New"),
+                                                             perspectiveName);
+
+        // open the same docked screen twice
+        url = BookmarkableUrlHelper.registerOpenedDock(url,
+                                                       dock1);
+        url = BookmarkableUrlHelper.registerOpenedDock(url,
+                                                       dock1);
+        assertEquals(perspectiveName
+                             .concat(BookmarkableUrlHelper.PERSPECTIVE_SEP)
+                             .concat("screen1[WdockedScreen,]"),
+                     url);
+        // open the another docked screen twice
+        url = BookmarkableUrlHelper.registerOpenedDock(url,
+                                                       dock2);
+        url = BookmarkableUrlHelper.registerOpenedDock(url,
+                                                       dock2);
+        assertEquals(perspectiveName
+                             .concat(BookmarkableUrlHelper.PERSPECTIVE_SEP)
+                             .concat("screen1[WdockedScreen,WdockedScreenNew,]"),
+                     url);
+    }
+
+    @Test
+    public void testRegisterClosedDock() {
+        final String dockName1 = "dockedScreen1";
+        final String dockName2 = "dockedScreen2";
+        String perspectiveName = "perspective";
+        String url = "perspectiveName|screen[W" + dockName1 + ",W" + dockName2 + ",]";
+        UberfireDock dock1 = createUberfireDockForTest(dockName1,
+                                                       perspectiveName);
+        UberfireDock dock2 = createUberfireDockForTest(dockName2,
+                                                       perspectiveName);
+
+        url = BookmarkableUrlHelper.registerClosedDock(url,
+                                                       dock1);
+        assertNotNull(url);
+        assertTrue(url.contains("!W" + dockName1));
+
+        url = BookmarkableUrlHelper.registerClosedDock(url,
+                                                       dock2);
+        assertNotNull(url);
+        assertTrue(url.contains("!W" + dockName2));
+    }
+
+    @Test
+    public void testDoubleRegisterClosedDock() {
+        final String dockName1 = "dockedScreen1";
+        final String dockName2 = "dockedScreen2";
+        String perspectiveName = "perspective";
+        String url = "perspectiveName|screen[W" + dockName1 + ",W" + dockName2 + ",]";
+        UberfireDock dock1 = createUberfireDockForTest(dockName1,
+                                                       perspectiveName);
+        UberfireDock dock2 = createUberfireDockForTest(dockName2,
+                                                       perspectiveName);
+
+        // close the same dock twice
+        url = BookmarkableUrlHelper.registerClosedDock(url,
+                                                       dock1);
+        url = BookmarkableUrlHelper.registerClosedDock(url,
+                                                       dock1);
+        assertNotNull(url);
+        assertTrue(url.contains("!W" + dockName1));
+        // close another dock twice
+        url = BookmarkableUrlHelper.registerClosedDock(url,
+                                                       dock2);
+        url = BookmarkableUrlHelper.registerClosedDock(url,
+                                                       dock2);
+        assertNotNull(url);
+        assertTrue(url.contains("!W" + dockName2));
+
+        // test with invalid dock and URl
+        String expected = "anyBookmarkableUrl";
+        url = BookmarkableUrlHelper.registerClosedDock(expected,
+                                                  null);
+        assertNotNull(url);
+        assertEquals(expected,url);
+
+        expected = "    "; // empty string for URL
+        url = BookmarkableUrlHelper.registerClosedDock(expected,
+                                                       dock2);
+        assertNotNull(url);
+        assertEquals(expected, url);
+    }
+
+    /**
+     * Get a dock for the test
+     * @param dockName
+     * @param perspectiveName
+     * @return
+     */
+    private UberfireDock createUberfireDockForTest(String dockName,
+                                                   String perspectiveName) {
+        final PlaceRequest req = new DefaultPlaceRequest(dockName);
+        UberfireDock dock = new UberfireDock(
+                UberfireDockPosition.WEST,
+                "iconType",
+                req,
+                perspectiveName);
+
+        return dock;
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/PlaceHistoryHandlerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/PlaceHistoryHandlerTest.java
@@ -1,0 +1,514 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.mvp;
+
+import java.util.Set;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.internal.verification.Times;
+import org.uberfire.client.workbench.docks.UberfireDock;
+import org.uberfire.client.workbench.docks.UberfireDockPosition;
+import org.uberfire.client.workbench.docks.UberfireDocksInteractionEvent;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
+import org.uberfire.workbench.model.ActivityResourceType;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+
+//@RunWith(MockitoJUnitRunner.class)
+@RunWith(GwtMockitoTestRunner.class)
+public class PlaceHistoryHandlerTest {
+
+    private final WorkbenchScreenActivity screenActivity = mock(WorkbenchScreenActivity.class);
+    private final WorkbenchScreenActivity perspectiveActivity = mock(WorkbenchScreenActivity.class);
+
+    @Mock
+    private PlaceRequestHistoryMapper mapper;
+
+    @Spy
+    PlaceHistoryHandler placeHistoryHandler;
+
+    @Before
+    public void setup() {
+
+        when(screenActivity.isDynamic()).thenReturn(false);
+        when(screenActivity.isType(ActivityResourceType.SCREEN.name())).thenReturn(true);
+        when(screenActivity.onMayClose()).thenReturn(true);
+        when(screenActivity.preferredWidth()).thenReturn(26);
+        when(screenActivity.preferredHeight()).thenReturn(77);
+
+        when(perspectiveActivity.isDynamic()).thenReturn(false);
+        when(perspectiveActivity.isDefault()).thenReturn(true);
+        when(perspectiveActivity.isType(ActivityResourceType.PERSPECTIVE.name())).thenReturn(true);
+        when(perspectiveActivity.onMayClose()).thenReturn(true);
+        when(perspectiveActivity.preferredWidth()).thenReturn(26);
+        when(perspectiveActivity.preferredHeight()).thenReturn(77);
+    }
+
+    @Test
+    public void testPerspectiveFromUrlSimple() {
+        PlaceRequest req = new DefaultPlaceRequest("perspective");
+
+        PlaceRequest place = BookmarkableUrlHelper.getPerspectiveFromPlace(req);
+        assertNotNull(place);
+        assertEquals("perspective",
+                     place.getIdentifier());
+        assertSame(place,
+                   req);
+    }
+
+    @Test
+    public void testPerspectiveFromUrlWithHistory() {
+        final String REQUEST = "perspective|secreenOne,~screenTwo$screenThree";
+
+        PlaceRequest req = new DefaultPlaceRequest(REQUEST);
+
+        PlaceRequest place = BookmarkableUrlHelper.getPerspectiveFromPlace(req);
+        assertNotNull(place);
+        assertEquals("perspective",
+                     place.getIdentifier());
+        assertNotSame(place,
+                      req);
+    }
+
+    @Test
+    public void testRegisterExistingURL() {
+        final String REQUEST = "perspective|secreenOne,~screenTwo$screenThree";
+        final PlaceRequest req = new DefaultPlaceRequest(REQUEST);
+
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         req);
+        assertEquals(REQUEST,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+    }
+
+    @Test
+    public void testRegisterBuild() {
+        final String SCREEN1_ID = "screen1";
+        final String SCREEN2_ID = "screen2";
+        final String PERSPECTIVE_ID = "perspective";
+        final PlaceRequest screen1 = new DefaultPlaceRequest(SCREEN1_ID);
+        final PlaceRequest screen2 = new DefaultPlaceRequest(SCREEN2_ID);
+        final PlaceRequest perspective = new DefaultPlaceRequest(PERSPECTIVE_ID);
+
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen1);
+        assertEquals(SCREEN1_ID,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        final String SCREENS_OPEN_LIST = SCREEN1_ID.concat(",").concat(SCREEN2_ID);
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen2);
+        assertEquals(SCREENS_OPEN_LIST,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        final String PERSPECTIVE_STRING = PERSPECTIVE_ID.concat("|").concat(SCREENS_OPEN_LIST);
+        placeHistoryHandler.registerOpen(perspectiveActivity,
+                                         perspective);
+        assertEquals(PERSPECTIVE_STRING,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+    }
+
+    @Test
+    public void TestScreenCloseSimple() {
+        final String SCREEN1_ID = "screen1";
+        final String SCREEN2_ID = "screen2";
+        final PlaceRequest screen1 = new DefaultPlaceRequest(SCREEN1_ID);
+        final PlaceRequest screen2 = new DefaultPlaceRequest(SCREEN2_ID);
+
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen1);
+        assertEquals(SCREEN1_ID,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        final String CLOSED_SCREENS = "~".concat(SCREEN1_ID);
+        placeHistoryHandler.registerClose(screenActivity,
+                                          screen1);
+        assertEquals(CLOSED_SCREENS,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        String URL = "~".concat(SCREEN1_ID).concat(",").concat(SCREEN2_ID);
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen2);
+        assertEquals(URL,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        URL = "~".concat(SCREEN1_ID).concat(",~").concat(SCREEN2_ID);
+        placeHistoryHandler.registerClose(screenActivity,
+                                          screen2);
+        assertEquals(URL,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+    }
+
+    @Test
+    @SuppressWarnings(value = "all")
+    public void TestScreenCloseSimpleWithArgs() {
+        final String SCREEN1_ID = "screen1";
+        final String SCREEN2_ID = "screen2";
+        final PlaceRequest screen1 = new DefaultPlaceRequest(SCREEN1_ID);
+        final PlaceRequest screen2 = new DefaultPlaceRequest(SCREEN2_ID);
+        final String PAR1_KEY = "y";
+        final String PAR1_VALUE = "x";
+        final String PAR2_KEY = "a";
+        final String PAR2_VALUE = "b";
+        final String PARAM_TAIL =
+                getParamListForTest(PAR2_KEY,
+                                    PAR2_VALUE,
+                                    PAR1_KEY,
+                                    PAR1_VALUE);
+
+        screen1.addParameter(PAR1_KEY,
+                             PAR1_VALUE);
+        screen1.addParameter(PAR2_KEY,
+                             PAR2_VALUE);
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen1);
+        assertEquals(SCREEN1_ID.concat(PARAM_TAIL),
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        final String CLOSED_SCREENS = "~".concat(SCREEN1_ID)
+                .concat(PARAM_TAIL);
+        placeHistoryHandler.registerClose(screenActivity,
+                                          screen1);
+        assertEquals(CLOSED_SCREENS,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        String URL = "~".concat(SCREEN1_ID)
+                .concat(PARAM_TAIL)
+                .concat(",").concat(SCREEN2_ID);
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen2);
+        assertEquals(URL,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        URL = "~".concat(SCREEN1_ID)
+                .concat(PARAM_TAIL)
+                .concat(",~").concat(SCREEN2_ID);
+        placeHistoryHandler.registerClose(screenActivity,
+                                          screen2);
+        assertEquals(URL,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+    }
+
+    @Test
+    public void testOtherScreen() {
+        final String SCREEN1_ID = "screen1";
+        final String SCREEN2_ID = "screen2";
+        final String SCREEN3_ID = "screen3";
+        final String PERSPECTIVE_ID = "perspective";
+        final PlaceRequest screen1 = new DefaultPlaceRequest(SCREEN1_ID);
+        final PlaceRequest screen2 = new DefaultPlaceRequest(SCREEN2_ID);
+        final PlaceRequest screen3 = new DefaultPlaceRequest(SCREEN3_ID);
+        final PlaceRequest perspective = new DefaultPlaceRequest(PERSPECTIVE_ID);
+
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen1);
+        assertEquals(SCREEN1_ID,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        final String PERSPECTIVE_STRING = PERSPECTIVE_ID.concat("|").concat(SCREEN1_ID);
+        placeHistoryHandler.registerOpen(perspectiveActivity,
+                                         perspective);
+        assertEquals(PERSPECTIVE_STRING,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        String EXPECTED_URL = PERSPECTIVE_STRING.concat("$").concat(SCREEN2_ID);
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen2);
+        assertEquals(EXPECTED_URL,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        EXPECTED_URL = EXPECTED_URL.concat(",").concat(SCREEN3_ID);
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen3);
+        assertEquals(EXPECTED_URL,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+    }
+
+    @Test
+//    @SuppressWarnings(value = "all")
+    public void testCloseAllScreens() {
+        final PlaceRequest screen1 = new DefaultPlaceRequest(SCREEN1_ID);
+        final PlaceRequest screen2 = new DefaultPlaceRequest(SCREEN2_ID);
+        final PlaceRequest screen3 = new DefaultPlaceRequest(SCREEN3_ID);
+        final PlaceRequest screen4 = new DefaultPlaceRequest(SCREEN4_ID);
+
+        prepareCompleteUrlWithParamsForTests();
+
+        String EXPECTED_URL = "perspective|screen1,~screen2$screen3?y=x,screen4?y=x";
+        placeHistoryHandler.registerClose(screenActivity,
+                                          screen2);
+        assertEquals(EXPECTED_URL,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        EXPECTED_URL = "perspective|screen1,~screen2$screen4?y=x";
+        placeHistoryHandler.registerClose(screenActivity,
+                                          screen3);
+        assertEquals(EXPECTED_URL,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        EXPECTED_URL = "perspective|screen1,~screen2";
+        placeHistoryHandler.registerClose(screenActivity,
+                                          screen4);
+        assertEquals(EXPECTED_URL,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+        EXPECTED_URL = "perspective|~screen1,~screen2";
+        placeHistoryHandler.registerClose(screenActivity,
+                                          screen1);
+        assertEquals(EXPECTED_URL,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+    }
+
+    @Test
+    public void TestFlush() {
+        prepareCompleteUrlForTests();
+        placeHistoryHandler.flush();
+        assertNotNull(placeHistoryHandler.getCurrentBookmarkableURLStatus());
+        assertEquals("",
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+    }
+
+    /**
+     * Open a dock and then close it
+     */
+    @Test
+    public void testRegisterOpenDock() {
+        final String dockName = "testDock";
+        final String placeRequestName = "testPlacerequest";
+
+        // simulate an opened screen first
+        PlaceRequest place = new DefaultPlaceRequest(placeRequestName);
+        placeHistoryHandler.registerOpen(screenActivity, place);
+        // mock a dock
+        PlaceRequest dockPlace = new DefaultPlaceRequest(dockName);
+        UberfireDocksInteractionEvent openEvent = mock(UberfireDocksInteractionEvent.class);
+
+        UberfireDock dock = mock(UberfireDock.class);
+        // simulate a docked screen in west position
+        when(dock.getDockPosition()).thenReturn(UberfireDockPosition.WEST);
+        when(dock.getIdentifier()).thenReturn(dockName);
+        when(dock.getIconType()).thenReturn("iconType");
+        when(dock.getPlaceRequest()).thenReturn(dockPlace);
+
+        when(openEvent.getType()).thenReturn(UberfireDocksInteractionEvent.InteractionType.SELECTED);
+        when(openEvent.getTargetDock()).thenReturn(dock);
+        placeHistoryHandler.registerOpenDock(openEvent);
+
+        // compose the expected URL
+        StringBuilder expected = new StringBuilder(placeRequestName);
+        expected.append(BookmarkableUrlHelper.DOCK_BEGIN_SEP);
+        expected.append("W"); // dock was mocked in WEST position
+        expected.append(dockName);
+        expected.append(BookmarkableUrlHelper.SEPARATOR);
+        expected.append(BookmarkableUrlHelper.DOCK_CLOSE_SEP);
+        assertEquals(expected.toString(),
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+
+    }
+
+    @Test
+    public void testRegisterCloseDock() {
+        final String dockName = "testDock";
+        final String placeRequestName = "testPlacerequest";
+
+        // simulate an opened screen first
+        PlaceRequest place = new DefaultPlaceRequest(placeRequestName);
+        placeHistoryHandler.registerOpen(screenActivity, place);
+        // mock a dock
+        PlaceRequest dockPlace = new DefaultPlaceRequest(dockName);
+        UberfireDocksInteractionEvent openEvent = mock(UberfireDocksInteractionEvent.class);
+        UberfireDocksInteractionEvent closeEvent = mock(UberfireDocksInteractionEvent.class);
+
+        UberfireDock dock = mock(UberfireDock.class);
+        // simulate a docked screen in west position
+        when(dock.getDockPosition()).thenReturn(UberfireDockPosition.WEST);
+        when(dock.getIdentifier()).thenReturn(dockName);
+        when(dock.getIconType()).thenReturn("iconType");
+        when(dock.getPlaceRequest()).thenReturn(dockPlace);
+
+        when(openEvent.getType()).thenReturn(UberfireDocksInteractionEvent.InteractionType.SELECTED);
+        when(openEvent.getTargetDock()).thenReturn(dock);
+        when(closeEvent.getType()).thenReturn(UberfireDocksInteractionEvent.InteractionType.DESELECTED);
+        when(closeEvent.getTargetDock()).thenReturn(dock);
+        // open...
+        placeHistoryHandler.registerOpenDock(openEvent);
+        // ...close dock
+        placeHistoryHandler.registerCloseDock(closeEvent);
+
+        // compose the expected URL
+        StringBuilder expected = new StringBuilder(placeRequestName);
+        expected.append(BookmarkableUrlHelper.DOCK_BEGIN_SEP);
+        expected.append(BookmarkableUrlHelper.CLOSED_DOCK_PREFIX);
+        expected.append("W"); // dock was mocked in WEST position
+        expected.append(dockName);
+        expected.append(BookmarkableUrlHelper.SEPARATOR);
+        expected.append(BookmarkableUrlHelper.DOCK_CLOSE_SEP);
+        assertEquals(expected.toString(),
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+    }
+
+
+    @Test
+    public void testUrlLimit() {
+        int cnt = 0;
+        int length = 0;
+
+        do {
+            final PlaceRequest screen = new DefaultPlaceRequest("screen".concat(String.valueOf(cnt++)));
+
+            placeHistoryHandler.registerOpen(screenActivity,
+                                             screen);
+
+            if (length == placeHistoryHandler.getCurrentBookmarkableURLStatus().length()) {
+                break;
+            }
+            length = placeHistoryHandler.getCurrentBookmarkableURLStatus().length();
+        } while ((placeHistoryHandler.getCurrentBookmarkableURLStatus().length()
+                < BookmarkableUrlHelper.MAX_NAV_URL_SIZE + 100));
+        assertNotNull(placeHistoryHandler.getCurrentBookmarkableURLStatus());
+        assertFalse(placeHistoryHandler.getCurrentBookmarkableURLStatus().length()
+                            > BookmarkableUrlHelper.MAX_NAV_URL_SIZE);
+    }
+
+    @Test
+    public void testGetOpenScreens() {
+        final String url = "perspective|screen1,!screen2,~screen3$!screen4";
+        final PlaceRequest req = new DefaultPlaceRequest(url);
+
+        Set<String> opened = BookmarkableUrlHelper.getOpenedScreenFromPlace(req);
+        assertNotNull(opened);
+        assertEquals(3L, opened.size());
+        assertTrue(opened.contains(SCREEN1_ID));
+        assertTrue(opened.contains("!" + SCREEN2_ID));
+        assertTrue(opened.contains("!" + SCREEN4_ID));
+    }
+
+    @Test
+    public void testGetClosedScreens() {
+        final String url = "perspective|screen1,~!screen2,~screen3$~!screen4";
+        final PlaceRequest req = new DefaultPlaceRequest(url);
+
+        Set<String> closed = BookmarkableUrlHelper.getClosedScreenFromPlace(req);
+        assertNotNull(closed);
+        assertEquals(3L, closed.size());
+        assertTrue(closed.contains("~" + SCREEN3_ID));
+        assertTrue(closed.contains("~!" + SCREEN2_ID));
+        assertTrue(closed.contains("~!" + SCREEN4_ID));
+    }
+
+    /**
+     * Prepare an URL -> perspective|screen1,screen2$screen3,screen4
+     */
+    private void prepareCompleteUrlForTests() {
+        final PlaceRequest screen1 = new DefaultPlaceRequest(SCREEN1_ID);
+        final PlaceRequest screen2 = new DefaultPlaceRequest(SCREEN2_ID);
+        final PlaceRequest screen3 = new DefaultPlaceRequest(SCREEN3_ID);
+        final PlaceRequest screen4 = new DefaultPlaceRequest(SCREEN4_ID);
+        final PlaceRequest perspective = new DefaultPlaceRequest(PERSPECTIVE_ID);
+        final String expectedUrl = "perspective|screen1,screen2$screen3,screen4";
+
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen1);
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen2);
+        placeHistoryHandler.registerOpen(perspectiveActivity,
+                                         perspective);
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen3);
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen4);
+        assertEquals(expectedUrl,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+    }
+
+    /**
+     * Prepare an URL -> perspective|screen1,screen2$screen3?y=x,screen4?y=x
+     */
+//    @SuppressWarnings(value = "all")
+    private void prepareCompleteUrlWithParamsForTests() {
+        final PlaceRequest screen1 = new DefaultPlaceRequest(SCREEN1_ID);
+        final PlaceRequest screen2 = new DefaultPlaceRequest(SCREEN2_ID);
+        final PlaceRequest screen3 = new DefaultPlaceRequest(SCREEN3_ID);
+        final PlaceRequest screen4 = new DefaultPlaceRequest(SCREEN4_ID);
+        final PlaceRequest perspective = new DefaultPlaceRequest(PERSPECTIVE_ID);
+        final String PAR_KEY = "y";
+        final String PAR_VALUE = "x";
+        final String PARAM_TAIL =
+                getParamListForTest(PAR_KEY,
+                                    PAR_VALUE);
+        final String expectedUrl = "perspective|screen1,screen2$screen3"
+                + PARAM_TAIL + ",screen4" + PARAM_TAIL;
+
+        screen3.addParameter(PAR_KEY,
+                             PAR_VALUE);
+        screen4.addParameter(PAR_KEY,
+                             PAR_VALUE);
+
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen1);
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen2);
+        placeHistoryHandler.registerOpen(perspectiveActivity,
+                                         perspective);
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen3);
+        placeHistoryHandler.registerOpen(screenActivity,
+                                         screen4);
+        assertEquals(expectedUrl,
+                     placeHistoryHandler.getCurrentBookmarkableURLStatus());
+    }
+
+    /**
+     * Return the list of parameters needed for test
+     * @param txt
+     * @return
+     */
+    private String getParamListForTest(String... txt) {
+        boolean isQM = true;
+        StringBuilder param = new StringBuilder();
+
+        for (int i = 0; i < txt.length; i++) {
+            if ((i == 0)
+                    || (i % 2 == 0)) {
+                if (isQM) {
+                    param.append("?");
+                    isQM = false;
+                } else {
+                    param.append("&");
+                }
+                param.append(txt[i]);
+            } else {
+                param.append("=");
+                param.append(txt[i]);
+            }
+        }
+        return param.toString();
+    }
+
+    final static String SCREEN1_ID = "screen1";
+    final static String SCREEN2_ID = "screen2";
+    final static String SCREEN3_ID = "screen3";
+    final static String SCREEN4_ID = "screen4";
+    final static String PERSPECTIVE_ID = "perspective";
+}


### PR DESCRIPTION
Bookmarkable URL - with this commit the URL reflects the status of the current perspective with its screens.
The URL is composed in the following way (special characters will be encoded of course):

* the perspective name is between the '#' and the '|' special characters;
* docks are contained in square brackets 
* screens not belonging to the current perspective are placed after a '$'
* non-docked closed screens are prepended with a '~'
* docked closed screens are prepended with a '!'

eg.:
http://127.0.0.1:8888/wires.html#WiresScratchPadPerspective|WiresScratchPadScreen,WiresLayersScreen,~WiresActionsScreen,WiresPaletteScreen,~WiresPropertiesScreen

http://127.0.0.1:8888/wires.html#UFWidgets|PagedTableScreen[WSimpleDockScreen,]

http://127.0.0.1:8888/kie-drools-wb.jsp#LibraryPerspective|$ProjectScreen,GuvnorDefaultFileEditor?path_uri=default://master@myrepo/itorders/src/main/resources/org/jbpm/demo/itorders/itorders-data.place-order-svg.svg&file_name=itorders-data.place-order-svg.svg&has_version_support=true[!Worg.kie.guvnor.explorer,],