### PR TITLE
[Layout Editor + Bookmarkable URL] Don't track places on preview and proper cleanup of screen components

### DIFF
--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorView.css
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorView.css
@@ -112,7 +112,9 @@
 .le-kebab {
     width: 10px;
     float: right;
+    z-index: 10;
 }
+
 .le-kebab-dropdown {
 }
 

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/api/LayoutDragComponent.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/api/LayoutDragComponent.java
@@ -44,4 +44,13 @@ public interface LayoutDragComponent {
      * @param ctx The context for the component being rendered
      */
     IsWidget getShowWidget(RenderingContext ctx);
+
+    /**
+     * A command called before the widget was removed from layout.
+     * This is usually used for cleanup tasks.
+     * @param ctx The context for the component being rendered
+     */
+    default void removeCurrentWidget(RenderingContext ctx){
+    }
+
 }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/api/RenderingContext.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/api/RenderingContext.java
@@ -32,6 +32,10 @@ public class RenderingContext {
         this.container = container;
     }
 
+    public RenderingContext(LayoutComponent component) {
+        this.component = component;
+    }
+
     public LayoutComponent getComponent() {
         return component;
     }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnView.java
@@ -32,6 +32,7 @@ import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.client.workbench.docks.UberfireDocksInteractionEvent;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
+import org.uberfire.ext.layout.editor.client.api.RenderingContext;
 import org.uberfire.ext.layout.editor.client.infra.ColumnDrop;
 import org.uberfire.ext.layout.editor.client.infra.ContainerResizeEvent;
 import org.uberfire.ext.layout.editor.client.infra.DragComponentEndEvent;
@@ -77,13 +78,13 @@ public class ComponentColumnView
     @DataField
     private Div right;
     @Inject
-    @DataField
-    private Div content;
-    @Inject
     @DataField("content-area")
     private Div contentArea;
     @Inject
-    private KebabWidget kebabWidget;
+    KebabWidget kebabWidget;
+    @Inject
+    @DataField
+    Div content;
     @Inject
     private Document document;
     private ColumnDrop.Orientation contentDropOrientation;
@@ -133,7 +134,7 @@ public class ComponentColumnView
                     heightSize);
     }
 
-    private void setupOnResize() {
+    void setupOnResize() {
         document.getBody().setOnresize(event -> calculateWidth());
     }
 
@@ -142,11 +143,18 @@ public class ComponentColumnView
     }
 
     private void setupKebabWidget() {
-        kebabWidget.init(() -> presenter.remove(),
+        kebabWidget.init(() -> {
+                             removeCurrentWidget();
+                             presenter.remove();
+                         },
                          () -> presenter.edit());
     }
 
-    private void setupEvents() {
+    void removeCurrentWidget() {
+        helper.getLayoutDragComponent().removeCurrentWidget(new RenderingContext(presenter.getLayoutComponent()));
+    }
+
+    void setupEvents() {
         setupLeftEvents();
         setupRightEvents();
         setupColUpEvents();
@@ -495,6 +503,7 @@ public class ComponentColumnView
     @Override
     public void clearContent() {
         removeAllChildren(content);
+        removeCurrentWidget();
     }
 
     @Override

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnViewTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/columns/ComponentColumnViewTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.layout.editor.client.components.columns;
+
+import com.google.gwt.user.client.Event;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jboss.errai.common.client.dom.Div;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.ext.layout.editor.client.widgets.KebabWidget;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ComponentColumnViewTest {
+
+    ComponentColumnView componentColumnView;
+    private KebabWidget kebabWidget;
+    private ComponentColumn presenter;
+
+    @Before
+    public void setup() {
+        componentColumnView = spy(new ComponentColumnView());
+        componentColumnView.content = mock(Div.class);
+        kebabWidget = spy(new KebabWidget());
+        componentColumnView.kebabWidget = kebabWidget;
+        presenter = mock(ComponentColumn.class);
+    }
+
+    @Test
+    public void setupKebabWidgetTest() {
+        componentColumnView.init(presenter);
+
+        doNothing().when(componentColumnView).setupEvents();
+        doNothing().when(componentColumnView).setupOnResize();
+        doNothing().when(componentColumnView).removeCurrentWidget();
+        componentColumnView.setupWidget();
+
+        verify(kebabWidget).init(any(),
+                                 any());
+
+        kebabWidget.removeClick(mock(Event.class));
+
+        verify(componentColumnView).removeCurrentWidget();
+        verify(presenter).remove();
+
+        kebabWidget.editClick(mock(Event.class));
+
+        verify(presenter).edit();
+    }
+
+    @Test
+    public void clearContentTest() {
+        doNothing().when(componentColumnView).removeCurrentWidget();
+        componentColumnView.init(presenter);
+
+        componentColumnView.clearContent();
+
+        verify(componentColumnView).removeCurrentWidget();
+    }
+}

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/perspective/editor/layout/editor/ScreenLayoutDragComponentTest.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/test/java/org/uberfire/ext/plugin/client/perspective/editor/layout/editor/ScreenLayoutDragComponentTest.java
@@ -17,27 +17,40 @@
 package org.uberfire.ext.plugin.client.perspective.editor.layout.editor;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.client.mvp.ActivityBeansInfo;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
+import org.uberfire.ext.layout.editor.client.api.RenderingContext;
 import org.uberfire.ext.plugin.event.NewPluginRegistered;
 import org.uberfire.ext.plugin.event.PluginUnregistered;
 import org.uberfire.ext.plugin.model.PluginType;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
 
 import static org.jgroups.util.Util.assertEquals;
 import static org.mockito.Mockito.*;
 
+@RunWith(MockitoJUnitRunner.class)
 public class ScreenLayoutDragComponentTest {
 
     private ScreenLayoutDragComponent screenLayoutDragComponent;
 
     private ActivityBeansInfo activityBeansInfo;
 
+    @Mock
+    private PlaceManager placeManager;
+
     @Before
     public void setup() {
-        screenLayoutDragComponent = spy(new ScreenLayoutDragComponent());
+        screenLayoutDragComponent = spy(new ScreenLayoutDragComponent(placeManager));
 
         activityBeansInfo = spy(new ActivityBeansInfo());
 
@@ -98,5 +111,42 @@ public class ScreenLayoutDragComponentTest {
                                                                               PluginType.SCREEN));
         assertEquals(3,
                      screenLayoutDragComponent.getAvailableWorkbenchScreensIds().size());
+    }
+
+    @Test
+    public void removeCurrentWidgetTest() {
+        RenderingContext renderingContext = mock(RenderingContext.class);
+        LayoutComponent t = new LayoutComponent();
+        t.addProperty(ScreenLayoutDragComponent.PLACE_NAME_PARAMETER,
+                      "dora");
+
+        when(renderingContext.getComponent()).thenReturn(t);
+
+        screenLayoutDragComponent.removeCurrentWidget(renderingContext);
+
+        verify(placeManager).closePlace(any(DefaultPlaceRequest.class));
+    }
+
+    @Test
+    public void buildPlaceRequestTest() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(ScreenLayoutDragComponent.PLACE_NAME_PARAMETER,
+                       "dora");
+        properties.put("dora1",
+                       "dora1");
+        DefaultPlaceRequest defaultPlaceRequest = screenLayoutDragComponent.buildPlaceRequest(properties);
+
+        assertEquals("dora",
+                     defaultPlaceRequest.getIdentifier());
+        assertEquals(2,
+                     defaultPlaceRequest.getParameters().size());
+    }
+
+    @Test
+    public void createCleanupPlaceRequestTest() {
+        DefaultPlaceRequest dora = new DefaultPlaceRequest("dora");
+        screenLayoutDragComponent.createCleanupPlaceRequest(dora).execute();
+
+        verify(placeManager).closePlace(dora);
     }
 }


### PR DESCRIPTION
Basically, two things addressed by this PR:

- Remove this hack: 
 newProperties.put("random",		+        DefaultPlaceRequest place = new DefaultPlaceRequest(placeName,]     "" + (new Random().nextLong()));

The root cause for this is that I cannot close the screens when I remove them from the layout.

- Don't track the preview of screens on layout editor on the url:
DefaultPlaceRequest place = new DefaultPlaceRequest(placeName, properties, false)
