### PR TITLE
AF-546: Reduce startup time of AppFormer apps and workbenches

### DIFF
--- a/uberfire-extensions/uberfire-apps/uberfire-apps-client/src/main/java/org/uberfire/ext/apps/client/home/AppsHomeView.java
+++ b/uberfire-extensions/uberfire-apps/uberfire-apps-client/src/main/java/org/uberfire/ext/apps/client/home/AppsHomeView.java
@@ -17,7 +17,16 @@
 package org.uberfire.ext.apps.client.home;
 
 import java.util.List;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
+
+import org.gwtbootstrap3.client.ui.AnchorListItem;
+import org.gwtbootstrap3.client.ui.Breadcrumbs;
+import org.uberfire.ext.apps.api.Directory;
+import org.uberfire.ext.apps.api.DirectoryBreadcrumb;
+import org.uberfire.ext.apps.client.home.components.TilesApp;
+import org.uberfire.mvp.ParameterizedCommand;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -27,13 +36,6 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Widget;
-import org.gwtbootstrap3.client.ui.AnchorListItem;
-import org.gwtbootstrap3.client.ui.Breadcrumbs;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
-import org.uberfire.ext.apps.api.Directory;
-import org.uberfire.ext.apps.api.DirectoryBreadcrumb;
-import org.uberfire.ext.apps.client.home.components.TilesApp;
-import org.uberfire.mvp.ParameterizedCommand;
 
 @Dependent
 public class AppsHomeView extends Composite implements AppsHomePresenter.View {
@@ -49,7 +51,7 @@ public class AppsHomeView extends Composite implements AppsHomePresenter.View {
     FlowPanel dirContent;
     private AppsHomePresenter presenter;
 
-    @AfterInitialization
+    @PostConstruct
     public void initialize() {
         initWidget(uiBinder.createAndBindUi(this));
     }

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/RuntimePluginsEntryPoint.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/RuntimePluginsEntryPoint.java
@@ -16,16 +16,19 @@
 
 package org.uberfire.ext.plugin.client;
 
+import static com.google.gwt.core.client.ScriptInjector.TOP_WINDOW;
+import static org.uberfire.workbench.model.ActivityResourceType.EDITOR;
+import static org.uberfire.workbench.model.ActivityResourceType.PERSPECTIVE;
+import static org.uberfire.workbench.model.ActivityResourceType.POPUP;
+import static org.uberfire.workbench.model.ActivityResourceType.SCREEN;
+
 import java.util.Collection;
+
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import com.google.gwt.core.client.ScriptInjector;
-import com.google.gwt.dom.client.StyleInjector;
-import org.jboss.errai.bus.client.api.ClientMessageBus;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EnabledByProperty;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ui.shared.api.annotations.Bundle;
@@ -48,11 +51,8 @@ import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.security.ResourceType;
 import org.uberfire.workbench.model.menu.MenuFactory;
 
-import static com.google.gwt.core.client.ScriptInjector.TOP_WINDOW;
-import static org.uberfire.workbench.model.ActivityResourceType.EDITOR;
-import static org.uberfire.workbench.model.ActivityResourceType.PERSPECTIVE;
-import static org.uberfire.workbench.model.ActivityResourceType.POPUP;
-import static org.uberfire.workbench.model.ActivityResourceType.SCREEN;
+import com.google.gwt.core.client.ScriptInjector;
+import com.google.gwt.dom.client.StyleInjector;
 
 @EntryPoint
 @Bundle("resources/i18n/Constants.properties")
@@ -64,9 +64,6 @@ public class RuntimePluginsEntryPoint {
 
     @Inject
     private Caller<PluginServices> pluginServices;
-
-    @Inject
-    private ClientMessageBus bus;
 
     @Inject
     private WorkbenchMenuBar menubar;
@@ -81,10 +78,6 @@ public class RuntimePluginsEntryPoint {
     public void init() {
         WebAppResource.INSTANCE.CSS().ensureInjected();
         workbench.addStartupBlocker(RuntimePluginsEntryPoint.class);
-    }
-
-    @AfterInitialization
-    public void setup() {
         pluginServices.call(new RemoteCallback<Collection<RuntimePlugin>>() {
             @Override
             public void callback(Collection<RuntimePlugin> response) {

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/config/PluginConfigService.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/config/PluginConfigService.java
@@ -16,11 +16,11 @@
 
 package org.uberfire.ext.plugin.client.config;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.uberfire.ext.plugin.service.PluginServices;
 
@@ -32,7 +32,7 @@ public class PluginConfigService {
 
     private String mediaServletURI;
 
-    @AfterInitialization
+    @PostConstruct
     public void init() {
         pluginServices.call(new RemoteCallback<String>() {
             @Override

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/generator/PerspectiveEditorGenerator.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/generator/PerspectiveEditorGenerator.java
@@ -16,23 +16,24 @@
 
 package org.uberfire.ext.plugin.client.perspective.editor.generator;
 
+import static org.jboss.errai.ioc.client.QualifierUtil.DEFAULT_QUALIFIERS;
+
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.RemoteCallback;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
-import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.IOCBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
-import org.jboss.errai.ioc.client.container.SyncBeanManagerImpl;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.uberfire.client.exporter.SingletonBeanDef;
 import org.uberfire.client.mvp.Activity;
 import org.uberfire.client.mvp.ActivityBeansCache;
@@ -47,12 +48,13 @@ import org.uberfire.ext.plugin.model.LayoutEditorModel;
 import org.uberfire.ext.plugin.model.PluginType;
 import org.uberfire.ext.plugin.service.PluginServices;
 
-import static org.jboss.errai.ioc.client.QualifierUtil.DEFAULT_QUALIFIERS;
-
 @EntryPoint
 public class PerspectiveEditorGenerator {
 
-    private SyncBeanManagerImpl beanManager;
+    @Inject
+    private SyncBeanManager beanManager;
+
+    @Inject
     private ActivityBeansCache activityBeansCache;
 
     @Inject
@@ -65,12 +67,6 @@ public class PerspectiveEditorGenerator {
     private Caller<LayoutServices> layoutServices;
 
     @PostConstruct
-    public void setup() {
-        beanManager = (SyncBeanManagerImpl) IOC.getBeanManager();
-        activityBeansCache = beanManager.lookupBean(ActivityBeansCache.class).getInstance();
-    }
-
-    @AfterInitialization
     public void loadPerspectives() {
         pluginServices.call(new RemoteCallback<Collection<LayoutEditorModel>>() {
             @Override
@@ -136,9 +132,9 @@ public class PerspectiveEditorGenerator {
         PerspectiveEditorScreenActivity activity = new PerspectiveEditorScreenActivity(perspective,
                                                                                        layoutGenerator);
 
-        final Set<Annotation> qualifiers = new HashSet<Annotation>(Arrays.asList(DEFAULT_QUALIFIERS));
+        final Set<Annotation> qualifiers = new HashSet<>(Arrays.asList(DEFAULT_QUALIFIERS));
         final SingletonBeanDef<PerspectiveEditorScreenActivity, PerspectiveEditorScreenActivity> beanDef =
-                new SingletonBeanDef<PerspectiveEditorScreenActivity, PerspectiveEditorScreenActivity>(
+                new SingletonBeanDef<>(
                         activity,
                         PerspectiveEditorScreenActivity.class,
                         qualifiers,

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/src/main/java/org/uberfire/ext/security/management/client/ClientUserSystemManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client/src/main/java/org/uberfire/ext/security/management/client/ClientUserSystemManager.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,6 +18,8 @@ package org.uberfire.ext.security.management.client;
 
 import java.util.Collection;
 import java.util.Map;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -106,7 +108,7 @@ public class ClientUserSystemManager implements UserSystemManager {
         this.isActive = false;
     }
 
-    @AfterInitialization
+    @PostConstruct
     public void initCache() {
         initializeCache(new Command() {
                             @Override

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/CommonsEntryPoint.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/CommonsEntryPoint.java
@@ -15,7 +15,8 @@
  */
 package org.uberfire.ext.widgets.common.client;
 
-import org.jboss.errai.ioc.client.api.AfterInitialization;
+import javax.annotation.PostConstruct;
+
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.uberfire.ext.widgets.common.client.resources.CommonResources;
 
@@ -25,7 +26,7 @@ import org.uberfire.ext.widgets.common.client.resources.CommonResources;
 @EntryPoint
 public class CommonsEntryPoint {
 
-    @AfterInitialization
+    @PostConstruct
     public void startApp() {
         //Ensure CSS has been loaded
         CommonResources.INSTANCE.CSS().ensureInjected();

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/UberfireBreadcrumbs.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/UberfireBreadcrumbs.java
@@ -21,12 +21,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.HasWidgets;
 import org.jboss.errai.common.client.dom.Element;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.uberfire.client.mvp.PlaceManager;
@@ -75,7 +76,7 @@ public class UberfireBreadcrumbs {
         updateView();
     }
 
-    @AfterInitialization
+    @PostConstruct
     public void createBreadcrumbs() {
         uberfireBreadcrumbsContainer.init(getView().getElement());
     }

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/CoreEntryPoint.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-core/uberfire-widgets-core-client/src/main/java/org/uberfire/ext/widgets/core/client/CoreEntryPoint.java
@@ -15,7 +15,8 @@
  */
 package org.uberfire.ext.widgets.core.client;
 
-import org.jboss.errai.ioc.client.api.AfterInitialization;
+import javax.annotation.PostConstruct;
+
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.uberfire.ext.widgets.core.client.resources.TreeNavigatorResources;
 import org.uberfire.ext.widgets.core.client.resources.WizardResources;
@@ -26,7 +27,7 @@ import org.uberfire.ext.widgets.core.client.resources.WizardResources;
 @EntryPoint
 public class CoreEntryPoint {
 
-    @AfterInitialization
+    @PostConstruct
     public void startApp() {
         //Ensure CSS has been loaded
         WizardResources.INSTANCE.css().ensureInjected();

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/src/main/java/org/uberfire/ext/widgets/table/client/TableEntryPoint.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-table/src/main/java/org/uberfire/ext/widgets/table/client/TableEntryPoint.java
@@ -15,14 +15,15 @@
  */
 package org.uberfire.ext.widgets.table.client;
 
-import org.jboss.errai.ioc.client.api.AfterInitialization;
+import javax.annotation.PostConstruct;
+
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.uberfire.ext.widgets.table.client.resources.UFTableResources;
 
 @EntryPoint
 public class TableEntryPoint {
 
-    @AfterInitialization
+    @PostConstruct
     public void startApp() {
         UFTableResources.INSTANCE.CSS().ensureInjected();
     }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/ShowcaseEntryPoint.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/ShowcaseEntryPoint.java
@@ -15,14 +15,11 @@
  */
 package org.uberfire.ext.wires.client;
 
+import static org.uberfire.workbench.model.menu.MenuFactory.newTopLevelMenu;
+
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import com.google.gwt.animation.client.Animation;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.user.client.ui.RootPanel;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.uberfire.client.mvp.ActivityManager;
 import org.uberfire.client.mvp.PlaceManager;
@@ -35,7 +32,11 @@ import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.workbench.model.menu.MenuPosition;
 import org.uberfire.workbench.model.menu.Menus;
 
-import static org.uberfire.workbench.model.menu.MenuFactory.newTopLevelMenu;
+import com.google.gwt.animation.client.Animation;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.ui.RootPanel;
 
 /**
  * GWT's Entry-point for Wires
@@ -59,7 +60,7 @@ public class ShowcaseEntryPoint {
         $wnd.location = url;
     }-*/;
 
-    @AfterInitialization
+    @PostConstruct
     public void startApp() {
         setupMenu();
         setupSettings();

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/navbar/AppNavBar.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/navbar/AppNavBar.java
@@ -16,18 +16,18 @@
 
 package org.uberfire.ext.wires.client.navbar;
 
+import static java.lang.Integer.MAX_VALUE;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.Div;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.uberfire.client.workbench.Header;
 import org.uberfire.client.workbench.widgets.menu.WorkbenchMenuBarPresenter;
-
-import static java.lang.Integer.MAX_VALUE;
 
 @ApplicationScoped
 @Templated
@@ -40,7 +40,7 @@ public class AppNavBar implements Header {
     @Inject
     private WorkbenchMenuBarPresenter menuBarPresenter;
 
-    @AfterInitialization
+    @PostConstruct
     public void setup() {
         DOMUtil.appendWidgetToElement(header,
                                       menuBarPresenter.getView().asWidget());

--- a/uberfire-js/src/main/java/org/uberfire/client/JSEntryPoint.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/JSEntryPoint.java
@@ -16,19 +16,20 @@
 
 package org.uberfire.client;
 
+import static com.google.gwt.core.client.ScriptInjector.TOP_WINDOW;
+
 import java.util.Collection;
+
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import com.google.gwt.core.client.ScriptInjector;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EnabledByProperty;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.uberfire.client.plugin.RuntimePluginsServiceProxy;
 import org.uberfire.client.workbench.Workbench;
 import org.uberfire.mvp.ParameterizedCommand;
 
-import static com.google.gwt.core.client.ScriptInjector.TOP_WINDOW;
+import com.google.gwt.core.client.ScriptInjector;
 
 @EntryPoint
 @EnabledByProperty(value = "uberfire.plugin.mode.active", negated = true)
@@ -43,10 +44,6 @@ public class JSEntryPoint {
     @PostConstruct
     public void init() {
         workbench.addStartupBlocker(JSEntryPoint.class);
-    }
-
-    @AfterInitialization
-    public void setup() {
         runtimePluginsService.listFrameworksContent(new ParameterizedCommand<Collection<String>>() {
             @Override
             public void execute(final Collection<String> response) {

--- a/uberfire-js/src/main/java/org/uberfire/client/exporter/UberfireJSAPIExporter.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/exporter/UberfireJSAPIExporter.java
@@ -17,10 +17,11 @@
 package org.uberfire.client.exporter;
 
 import java.util.Collection;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
@@ -32,7 +33,7 @@ public class UberfireJSAPIExporter {
     @Inject
     Event<UberfireJSAPIReadyEvent> jsapiReadyEvent;
 
-    @AfterInitialization
+    @PostConstruct
     public void export() {
         Collection<SyncBeanDef<UberfireJSExporter>> jsAPIs = IOC.getBeanManager().lookupBeans(UberfireJSExporter.class);
         for (SyncBeanDef<UberfireJSExporter> bean : jsAPIs) {

--- a/uberfire-security/uberfire-security-client/src/main/java/org/uberfire/security/client/SecurityEntryPoint.java
+++ b/uberfire-security/uberfire-security-client/src/main/java/org/uberfire/security/client/SecurityEntryPoint.java
@@ -16,10 +16,10 @@
 
 package org.uberfire.security.client;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.uberfire.backend.authz.AuthorizationService;
 import org.uberfire.security.authz.AuthorizationPolicy;
@@ -34,7 +34,7 @@ public class SecurityEntryPoint {
     @Inject
     private PermissionManager permissionManager;
 
-    @AfterInitialization
+    @PostConstruct
     public void init() {
         authorizationService.call(
                 (AuthorizationPolicy p) -> {

--- a/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/navbar/AppNavBar.java
+++ b/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/navbar/AppNavBar.java
@@ -16,18 +16,18 @@
 
 package org.uberfire.client.navbar;
 
+import static java.lang.Integer.MAX_VALUE;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.Div;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.uberfire.client.workbench.Header;
 import org.uberfire.client.workbench.widgets.menu.WorkbenchMenuBarPresenter;
-
-import static java.lang.Integer.MAX_VALUE;
 
 @ApplicationScoped
 @Templated
@@ -40,7 +40,7 @@ public class AppNavBar implements Header {
     @Inject
     private WorkbenchMenuBarPresenter menuBarPresenter;
 
-    @AfterInitialization
+    @PostConstruct
     public void setup() {
         DOMUtil.appendWidgetToElement(header,
                                       menuBarPresenter.getView().asWidget());

--- a/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/client/ShowcaseEntryPoint.java
+++ b/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/client/ShowcaseEntryPoint.java
@@ -15,24 +15,25 @@
  */
 package org.uberfire.client;
 
-import java.util.*;
+import static org.uberfire.workbench.model.menu.MenuFactory.newTopLevelCustomMenu;
+import static org.uberfire.workbench.model.menu.MenuFactory.newTopLevelMenu;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
-import com.google.common.collect.Sets;
-import com.google.gwt.animation.client.Animation;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.Image;
-import com.google.gwt.user.client.ui.RootPanel;
-import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.ui.html.Text;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.IOCBeanDef;
@@ -52,6 +53,7 @@ import org.uberfire.client.perspectives.SimplePerspectiveNoContext;
 import org.uberfire.client.resources.AppResource;
 import org.uberfire.client.screen.JSWorkbenchScreenActivity;
 import org.uberfire.client.screens.popup.SimplePopUp;
+import org.uberfire.client.views.pfly.PatternFlyEntryPoint;
 import org.uberfire.client.views.pfly.menu.MainBrand;
 import org.uberfire.client.views.pfly.menu.UserMenu;
 import org.uberfire.client.views.pfly.modal.Bs3Modal;
@@ -69,8 +71,15 @@ import org.uberfire.workbench.model.menu.MenuFactory;
 import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.Menus;
 
-import static org.uberfire.workbench.model.menu.MenuFactory.newTopLevelCustomMenu;
-import static org.uberfire.workbench.model.menu.MenuFactory.newTopLevelMenu;
+import com.google.common.collect.Sets;
+import com.google.gwt.animation.client.Animation;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.user.client.ui.Widget;
 
 /**
  * GWT's Entry-point for Uberfire-showcase
@@ -109,6 +118,8 @@ public class ShowcaseEntryPoint {
     private SearchMenuBuilder searchMenuBuilder;
     @Inject
     private ErrorPopupView errorPopupView;
+    @Inject
+    private PatternFlyEntryPoint pflyEntryPoint;
 
     public static List<MenuItem> getScreens() {
         final List<MenuItem> screens = new ArrayList<>();
@@ -144,21 +155,13 @@ public class ShowcaseEntryPoint {
         return screens;
     }
 
-    @AfterInitialization
+    @PostConstruct
     public void startApp() {
         PatternFlyBootstrapper.ensureMomentIsAvailable();
         hideLoadingPopup();
-        GWT.log("PatternFly version: " + getPatternFlyVersion());
-        GWT.log("Loaded MomentJS using locale: " + getMomentLocale());
+        GWT.log("PatternFly version: " + pflyEntryPoint.getPatternFlyVersion());
+        GWT.log("Loaded MomentJS using locale: " + pflyEntryPoint.getMomentLocale());
     }
-
-    private native String getPatternFlyVersion()/*-{
-        return $wnd.patternfly.version;
-    }-*/;
-
-    private native String getMomentLocale()/*-{
-        return $wnd.moment.locale();
-    }-*/;
 
     private void setupMenu(@Observes final ApplicationReadyEvent event) {
         final PerspectiveActivity defaultPerspective = getDefaultPerspectiveActivity();
@@ -218,7 +221,7 @@ public class ShowcaseEntryPoint {
     }
 
     private List<MenuItem> getPerspectives() {
-        final List<MenuItem> perspectives = new ArrayList<MenuItem>();
+        final List<MenuItem> perspectives = new ArrayList<>();
         for (final PerspectiveActivity perspective : getPerspectiveActivities()) {
             if (SimplePerspectiveNoContext.SIMPLE_PERSPECTIVE_NO_CONTEXT.equals(perspective.getIdentifier())) {
                 continue;
@@ -264,7 +267,7 @@ public class ShowcaseEntryPoint {
         }
 
         //Sort Perspective Providers so they're always in the same sequence!
-        List<PerspectiveActivity> sortedActivities = new ArrayList<PerspectiveActivity>(activities);
+        List<PerspectiveActivity> sortedActivities = new ArrayList<>(activities);
         Collections.sort(sortedActivities,
                          new Comparator<PerspectiveActivity>() {
 

--- a/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/client/navbar/AppNavBar.java
+++ b/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/client/navbar/AppNavBar.java
@@ -16,18 +16,18 @@
 
 package org.uberfire.client.navbar;
 
+import static java.lang.Integer.MAX_VALUE;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.jboss.errai.common.client.dom.DOMUtil;
 import org.jboss.errai.common.client.dom.Div;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.uberfire.client.workbench.Header;
 import org.uberfire.client.workbench.widgets.menu.WorkbenchMenuBarPresenter;
-
-import static java.lang.Integer.MAX_VALUE;
 
 @ApplicationScoped
 @Templated
@@ -40,7 +40,7 @@ public class AppNavBar implements Header {
     @Inject
     private WorkbenchMenuBarPresenter menuBarPresenter;
 
-    @AfterInitialization
+    @PostConstruct
     public void setup() {
         DOMUtil.appendWidgetToElement(header,
                                       menuBarPresenter.getView().asWidget());

--- a/uberfire-workbench/uberfire-workbench-client-backend/src/main/java/org/uberfire/client/WorkbenchBackendEntryPoint.java
+++ b/uberfire-workbench/uberfire-workbench-client-backend/src/main/java/org/uberfire/client/WorkbenchBackendEntryPoint.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 import org.jboss.errai.bus.client.api.BusLifecycleAdapter;
 import org.jboss.errai.bus.client.api.BusLifecycleEvent;
 import org.jboss.errai.bus.client.api.ClientMessageBus;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.slf4j.Logger;
 import org.uberfire.client.workbench.WorkbenchServicesProxy;
@@ -58,18 +57,8 @@ public class WorkbenchBackendEntryPoint {
         this.errorPopupPresenter = errorPopupPresenter;
     }
 
-    @AfterInitialization
-    public void init() {
-        workbenchServices.isWorkbenchOnCluster(new ParameterizedCommand<Boolean>() {
-            @Override
-            public void execute(final Boolean parameter) {
-                isWorkbenchOnCluster = !(parameter == null || parameter.equals(Boolean.FALSE));
-            }
-        });
-    }
-
     @PostConstruct
-    public void postConstruct() {
+    public void init() {
         bus.addLifecycleListener(new BusLifecycleAdapter() {
             @Override
             public void busOnline(final BusLifecycleEvent e) {
@@ -87,6 +76,12 @@ public class WorkbenchBackendEntryPoint {
                     errorPopupPresenter.showMessage("You've been disconnected.");
                 }
                 showedError = true;
+            }
+        });
+        workbenchServices.isWorkbenchOnCluster(new ParameterizedCommand<Boolean>() {
+            @Override
+            public void execute(final Boolean parameter) {
+                isWorkbenchOnCluster = !(parameter == null || parameter.equals(Boolean.FALSE));
             }
         });
     }

--- a/uberfire-workbench/uberfire-workbench-client-backend/src/test/java/org/uberfire/client/WorkbenchBackendEntryPointTest.java
+++ b/uberfire-workbench/uberfire-workbench-client-backend/src/test/java/org/uberfire/client/WorkbenchBackendEntryPointTest.java
@@ -66,7 +66,6 @@ public class WorkbenchBackendEntryPointTest {
             }
         }).when(workbenchServices).isWorkbenchOnCluster(any(ParameterizedCommand.class));
 
-        workbenchBackendEntryPoint.postConstruct();
         workbenchBackendEntryPoint.init();
 
         final ArgumentCaptor<BusLifecycleListener> captor = ArgumentCaptor.forClass(BusLifecycleListener.class);
@@ -123,7 +122,6 @@ public class WorkbenchBackendEntryPointTest {
             }
         }).when(workbenchServices).isWorkbenchOnCluster(any(ParameterizedCommand.class));
 
-        workbenchBackendEntryPoint.postConstruct();
         workbenchBackendEntryPoint.init();
 
         final ArgumentCaptor<BusLifecycleListener> captor = ArgumentCaptor.forClass(BusLifecycleListener.class);

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/HTML5DndSeleniumSupport.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/HTML5DndSeleniumSupport.java
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package org.uberfire.client.exporter;
+package org.uberfire.client.views.pfly;
 
-import javax.enterprise.context.ApplicationScoped;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
 
-@ApplicationScoped
+import org.jboss.errai.ioc.client.api.EntryPoint;
+
 /**
  * This class is developed to provide an temporary HTML5 DnD API for Selenium.
  * Unfortunately, Selenium lack of support for HTML5 DnD.
@@ -27,10 +29,17 @@ import javax.enterprise.context.ApplicationScoped;
  * Usage: $('#origin').simulateDragDrop({ dropTarget: '#target'});
  *
  */
-public class HTML5DndSeleniumSupport implements UberfireJSExporter {
+@EntryPoint
+public class HTML5DndSeleniumSupport {
 
-    @Override
-    public void export() {
+    /*
+     * Ensures that JQuery is loaded before this runs.
+     */
+    @Inject
+    private PatternFlyEntryPoint entryPoint;
+
+    @PostConstruct
+    public void init() {
         prepareDnd(this);
     }
 

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/PatternFlyEntryPoint.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/PatternFlyEntryPoint.java
@@ -28,4 +28,12 @@ public class PatternFlyEntryPoint {
     public void init() {
         PatternFlyBootstrapper.ensurePatternFlyIsAvailable();
     }
+
+    public native String getPatternFlyVersion()/*-{
+        return $wnd.patternfly.version;
+    }-*/;
+
+    public native String getMomentLocale()/*-{
+        return $wnd.moment.locale();
+    }-*/;
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityBeansCache.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityBeansCache.java
@@ -25,13 +25,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.jboss.errai.ioc.client.api.EnabledByProperty;
-import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.uberfire.backend.vfs.Path;
@@ -46,7 +47,7 @@ import static java.util.Collections.sort;
 /**
  *
  */
-@EntryPoint
+@ApplicationScoped
 @EnabledByProperty(value = "uberfire.plugin.mode.active", negated = true)
 public class ActivityBeansCache {
 


### PR DESCRIPTION
* Convert @AfterInitializations to @PostConstructs so that RPC
calls are queued before the bus initializes (and sent in a single payload)
* Minor refactoring in Workbench setup
* Workbench now adds itself as a blocker, unblocked once Errai is fully initialized
* Move HTML5DndSeleniumSupport to a module that includes JQuery (has an
implicit dependency that was not previously guaranteed to be on the host page)