### PR TITLE
AF-536: [Bookmarkable URL] Cannot track closed editors

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/BookmarkableUrlHelper.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/BookmarkableUrlHelper.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import org.uberfire.client.workbench.docks.UberfireDock;
 import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.mvp.impl.PathPlaceRequest;
 
 /**
  * A bookmarkable URL has the following form:
@@ -398,6 +399,29 @@ public class BookmarkableUrlHelper {
         if (!currentBookmarkableURLStatus.contains(closed)) {
             return currentBookmarkableURLStatus.replace(id,
                                                         CLOSED_DOCK_PREFIX.concat(id));
+        }
+        return currentBookmarkableURLStatus;
+    }
+
+    /**
+     * Remove the editor reference from the URL
+     * @param currentBookmarkableURLStatus
+     * @param place
+     * @return
+     */
+    public static String registerCloseEditor(final String currentBookmarkableURLStatus,
+                                             final PlaceRequest place) {
+        if (place != null
+                && place instanceof PathPlaceRequest) {
+            final String path = place.getFullIdentifier();
+            final String pathWithSep = path.concat(SEPARATOR);
+
+            if (currentBookmarkableURLStatus.contains(pathWithSep)) {
+                return currentBookmarkableURLStatus.replace(pathWithSep,
+                                                            "");
+            }
+            return currentBookmarkableURLStatus.replace(path,
+                                                        "");
         }
         return currentBookmarkableURLStatus;
     }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceHistoryHandler.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceHistoryHandler.java
@@ -28,6 +28,7 @@ import com.google.web.bindery.event.shared.HandlerRegistration;
 import org.uberfire.client.workbench.docks.UberfireDocksInteractionEvent;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
+import org.uberfire.mvp.impl.PathPlaceRequest;
 import org.uberfire.workbench.model.ActivityResourceType;
 
 @ApplicationScoped
@@ -80,6 +81,12 @@ public class PlaceHistoryHandler {
     }
 
     private void updateHistoryBar() {
+        if (currentBookmarkableURLStatus.endsWith(BookmarkableUrlHelper.OTHER_SCREEN_SEP)) {
+
+            currentBookmarkableURLStatus =
+                    currentBookmarkableURLStatus.substring(0,
+                                                           currentBookmarkableURLStatus.length() - 1);
+        }
         historian.newItem(currentBookmarkableURLStatus,
                           false);
     }
@@ -170,14 +177,21 @@ public class PlaceHistoryHandler {
     public void registerClose(Activity activity,
                               PlaceRequest place) {
         if (place.isUpdateLocationBarAllowed()) {
-            final String id = place.getIdentifier();
-            if (activity.isType(ActivityResourceType.SCREEN.name())) {
-                final String token = BookmarkableUrlHelper.getUrlToken(currentBookmarkableURLStatus,
-                                                                       id);
-
+            if (place instanceof PathPlaceRequest) {
+                // handle editors
                 currentBookmarkableURLStatus =
-                        BookmarkableUrlHelper.registerClose(currentBookmarkableURLStatus,
-                                                            token);
+                        BookmarkableUrlHelper.registerCloseEditor(currentBookmarkableURLStatus,
+                                                                  place);
+            } else {
+                final String id = place.getIdentifier();
+                if (activity.isType(ActivityResourceType.SCREEN.name())) {
+                    final String token = BookmarkableUrlHelper.getUrlToken(currentBookmarkableURLStatus,
+                                                                           id);
+
+                    currentBookmarkableURLStatus =
+                            BookmarkableUrlHelper.registerClose(currentBookmarkableURLStatus,
+                                                                token);
+                }
             }
             updateHistoryBar();
         }


### PR DESCRIPTION
Bookmarkable URL is now updated when an editor screen is closed, fixes AF-536 Cannot track closed editors.
This ticket belongs to (UF-195) Implement bookmarkable URLs