### PR TITLE
AF-547: VFS commit batch broken

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/pom.xml
@@ -131,29 +131,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <includes>
-            <include>org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderBytemanTest</include>
-          </includes>
-          <useSystemClassLoader>true</useSystemClassLoader>
-          <useManifestOnlyJar>true</useManifestOnlyJar>
-          <forkMode>once</forkMode>
-          <!--<parallel>false</parallel>-->
-          <!-- ensure we don't inherit a byteman jar from any env settings -->
-          <environmentVariables>
-            <BYTEMAN_HOME></BYTEMAN_HOME>
-          </environmentVariables>
-          <systemProperties>
-            <property>
-              <name>org.jboss.byteman.home</name>
-              <value></value>
-            </property>
-          </systemProperties>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Perform dot file removal & file changes in a single commit by enforcing batch FS state. This simplifies version history in cases when a file is not saved within a batch boundary.

I also noticed maven-surefire-plugin configuration defined a single test only (with the rest skipped). If this is intentional, please let me know.

Part of:
https://github.com/kiegroup/guvnor/pull/473
https://github.com/AppFormer/uberfire/pull/764