### PR TITLE
[JBPM-6278] NullPointerException when configuring user and group management services using KC adapter provider

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/auth/adapter/KCAdapterContextTokenManager.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/main/java/org/uberfire/ext/security/management/keycloak/client/auth/adapter/KCAdapterContextTokenManager.java
@@ -49,6 +49,12 @@ public class KCAdapterContextTokenManager implements TokenManager {
     }
 
     protected KeycloakSecurityContext getKCSessionContext() {
-        return (KeycloakSecurityContext) request.getAttribute(KeycloakSecurityContext.class.getName());
+        KeycloakSecurityContext context = null;
+    	
+    	context = (KeycloakSecurityContext) request.getAttribute(KeycloakSecurityContext.class.getName());
+    	if (context == null) {
+    		context = (KeycloakSecurityContext) request.getSession().getAttribute(KeycloakSecurityContext.class.getName());
+    	}
+    	return context;
     }
 }

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/client/auth/adapter/KCAdapterContextTokenManagerTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-keycloak/src/test/java/org/uberfire/ext/security/management/keycloak/client/auth/adapter/KCAdapterContextTokenManagerTest.java
@@ -17,6 +17,7 @@
 package org.uberfire.ext.security.management.keycloak.client.auth.adapter;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,6 +34,10 @@ public class KCAdapterContextTokenManagerTest {
 
     @Mock
     HttpServletRequest request;
+    
+    @Mock
+    HttpSession session;
+    
     @Mock
     KeycloakSecurityContext context;
 
@@ -41,6 +46,8 @@ public class KCAdapterContextTokenManagerTest {
     @Before
     public void setup() throws Exception {
         when(request.getAttribute(KeycloakSecurityContext.class.getName())).thenReturn(context);
+        when(request.getSession()).thenReturn(session);
+        when(session.getAttribute(KeycloakSecurityContext.class.getName())).thenReturn(context);
         when(context.getTokenString()).thenReturn("token1");
         when(context.getRealm()).thenReturn("realm1");
         this.tested = new KCAdapterContextTokenManager(request);


### PR DESCRIPTION
Fixed #JBPM-6278 NullPointerException when configuring user and group management services using KC adapter provider

