### PR TITLE
[do not merge] JBPM-6148 - New CDI Profile API to include/exclude beans

### DIFF
--- a/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/profile/ProfileManager.java
+++ b/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/profile/ProfileManager.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.profile;
+
+import org.jboss.errai.bus.server.annotations.Remote;
+
+@Remote
+public interface ProfileManager {
+
+    boolean isProfileEnabled(String profile);
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/profile/ProfileExtension.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/profile/ProfileExtension.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi.profile;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+
+import org.uberfire.commons.services.cdi.Profile;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+public class ProfileExtension implements Extension {
+
+    <T> void processAnnotatedType(@Observes ProcessAnnotatedType<T> pat) {
+        final String profile = getProfileAnnotationValue(pat.getAnnotatedType().getJavaClass());
+        if(isNullOrEmpty(profile)){
+            return;
+        }
+
+        if (ProfileManagerImpl.isProfileActive(profile) == false) {
+            pat.veto();
+        }
+    }
+
+    private String getProfileAnnotationValue(final Class<?> aClass) {
+        final Profile[] annotationsByType = aClass.getAnnotationsByType(Profile.class);
+        if (annotationsByType.length > 0) {
+            return annotationsByType[0].value();
+        }
+        return getProfileAnnotationPackageValue(aClass.getPackage());
+    }
+
+    private String getProfileAnnotationPackageValue(final Package pkg) {
+        if(pkg == null){
+            return null;
+        }
+
+        final Profile[] annotationsByType = pkg.getAnnotationsByType(Profile.class);
+        if(annotationsByType.length > 0){
+            return annotationsByType[0].value();
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/profile/ProfileManagerImpl.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/profile/ProfileManagerImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi.profile;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.errai.bus.server.annotations.Service;
+import org.uberfire.backend.profile.ProfileManager;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+@Service
+@ApplicationScoped
+public class ProfileManagerImpl implements ProfileManager {
+
+    protected static final String PROFILE_SYSTEM_PROPERTY_NAME = "org.uberfire.profile.active";
+
+    public static boolean isProfileActive(final String profile) {
+        if (isNullOrEmpty(profile)) {
+            return false;
+        }
+        final String activeProfile = System.getProperty(PROFILE_SYSTEM_PROPERTY_NAME);
+        if (isNullOrEmpty(activeProfile)) {
+            return true;
+        } else {
+            return activeProfile.equals(profile);
+        }
+    }
+
+    @Override
+    public boolean isProfileEnabled(final String profile) {
+        return isProfileActive(profile);
+    }
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,2 +1,3 @@
+org.uberfire.backend.server.cdi.profile.ProfileExtension
 org.uberfire.backend.server.cdi.SystemConfigProducer
 org.uberfire.backend.server.cdi.workspace.WorkspaceScopedExtension

--- a/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/profile/ProfileManagerImplTest.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/profile/ProfileManagerImplTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi.profile;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.uberfire.backend.server.cdi.profile.ProfileManagerImpl.PROFILE_SYSTEM_PROPERTY_NAME;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProfileManagerImplTest {
+
+    private static String systemProfile = null;
+
+    @InjectMocks
+    ProfileManagerImpl profileManager;
+
+    @BeforeClass
+    public static void before(){
+        systemProfile = System.getProperty(PROFILE_SYSTEM_PROPERTY_NAME);
+    }
+
+    @AfterClass
+    public static void after(){
+        System.setProperty(PROFILE_SYSTEM_PROPERTY_NAME, systemProfile);
+    }
+
+    @Test
+    public void testProfileActive(){
+        assertFalse(profileManager.isProfileEnabled(null));
+        assertFalse(profileManager.isProfileEnabled(""));
+        assertTrue(profileManager.isProfileEnabled("runtime"));
+        System.setProperty(PROFILE_SYSTEM_PROPERTY_NAME, "authoring");
+        assertTrue(profileManager.isProfileEnabled("authoring"));
+        assertFalse(profileManager.isProfileEnabled("Authoring"));
+    }
+
+}

--- a/uberfire-commons/src/main/java/org/uberfire/commons/services/cdi/Profile.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/services/cdi/Profile.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.commons.services.cdi;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Defines a CDI profile where the target bean is available.
+ * If no profile is currently active, all beans are available.
+ *
+ */
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, PACKAGE})
+public @interface Profile {
+
+    String value();
+}

--- a/uberfire-showcase/uberfire-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-webapp/pom.xml
@@ -393,7 +393,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
         <configuration>
-          <extraJvmArgs>-Xmx2G -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.ioc.jsinterop.support=true</extraJvmArgs>
+          <extraJvmArgs>-Xmx2G -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home} -Derrai.ioc.jsinterop.support=true -Dorg.uberfire.profile.active=runtime</extraJvmArgs>
           <strict>true</strict>
           <logLevel>INFO</logLevel>
           <noServer>false</noServer>

--- a/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/backend/server/impl/ProfileTestService.java
+++ b/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/backend/server/impl/ProfileTestService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.impl;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+
+import org.uberfire.commons.services.cdi.Startup;
+import org.uberfire.commons.services.cdi.StartupType;
+
+@Startup(StartupType.BOOTSTRAP)
+@ApplicationScoped
+@TestProfile
+public class ProfileTestService {
+
+    @PostConstruct
+    public void init(){
+        throw new RuntimeException("test profile should not be active exception!");
+    }
+
+}

--- a/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/backend/server/impl/TestProfile.java
+++ b/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/backend/server/impl/TestProfile.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.impl;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.uberfire.commons.services.cdi.Profile;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, PACKAGE})
+@Profile("test")
+public @interface TestProfile {
+
+}

--- a/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/client/ShowcaseEntryPoint.java
+++ b/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/client/ShowcaseEntryPoint.java
@@ -41,6 +41,8 @@ import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.security.shared.api.Role;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.jboss.errai.security.shared.service.AuthenticationService;
+import org.slf4j.Logger;
+import org.uberfire.backend.profile.ProfileManager;
 import org.uberfire.client.menu.CustomSplashHelp;
 import org.uberfire.client.menu.WorkbenchViewModeSwitcherMenuBuilder;
 import org.uberfire.client.mvp.ActivityManager;
@@ -112,6 +114,10 @@ public class ShowcaseEntryPoint {
     private ErrorPopupView errorPopupView;
     @Inject
     private PatternFlyEntryPoint pflyEntryPoint;
+    @Inject
+    private Caller<ProfileManager> profileManager;
+    @Inject
+    private Logger logger;
 
     public static List<MenuItem> getScreens() {
         final List<MenuItem> screens = new ArrayList<>();
@@ -152,8 +158,10 @@ public class ShowcaseEntryPoint {
         PatternFlyBootstrapper.ensureMomentIsAvailable();
         PatternFlyBootstrapper.ensureBootstrapDateRangePickerIsAvailable();
         hideLoadingPopup();
-        GWT.log("PatternFly version: " + pflyEntryPoint.getPatternFlyVersion());
-        GWT.log("Loaded MomentJS using locale: " + pflyEntryPoint.getMomentLocale());
+        logger.info("PatternFly version: {}", pflyEntryPoint.getPatternFlyVersion());
+        logger.info("Loaded MomentJS using locale: {}", pflyEntryPoint.getMomentLocale());
+        profileManager.call(enabled -> logger.info("Is test profile active: {}",
+                                                   enabled)).isProfileEnabled("test");
     }
 
     private void setupMenu(@Observes final ApplicationReadyEvent event) {

--- a/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/client/screens/ProfileScreen.java
+++ b/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/client/screens/ProfileScreen.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.screens;
+
+import javax.annotation.PostConstruct;
+
+import com.google.gwt.user.client.ui.Label;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.client.annotations.WorkbenchScreen;
+import org.uberfire.commons.services.cdi.Profile;
+
+@WorkbenchScreen(identifier = "ProfileScreen")
+@Profile("test")
+public class ProfileScreen {
+
+    @PostConstruct
+    public void init() {
+        throw new RuntimeException("test profile should not be active exception!");
+    }
+
+    @WorkbenchPartTitle
+    public String getTitle() {
+        return "Profile Screen";
+    }
+
+    @WorkbenchPartView
+    public Label getView() {
+        return new Label(getTitle());
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/PerspectiveProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/PerspectiveProcessorTest.java
@@ -465,6 +465,60 @@ public class PerspectiveProcessorTest extends AbstractProcessorTest {
                      result.getActualCode());
     }
 
+    @Test
+    public void testProfileInTheActivity() throws FileNotFoundException {
+        final String pathCompilationUnit = "org/uberfire/annotations/processors/PerspectiveTest26";
+        final String pathExpectedResult = "org/uberfire/annotations/processors/expected/PerspectiveTest26.expected";
+
+        result.setExpectedCode(getExpectedSourceCode(pathExpectedResult));
+
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
+                getProcessorUnderTest(),
+                pathCompilationUnit);
+
+        assertSuccessfulCompilation(diagnostics);
+        assertNotNull(result.getActualCode());
+        assertNotNull(result.getExpectedCode());
+        assertEquals(result.getExpectedCode(),
+                     result.getActualCode());
+    }
+
+    @Test
+    public void testProfilePackageInTheActivity() throws FileNotFoundException {
+        final String pathCompilationUnit = "org/uberfire/annotations/processors/packagelevel/PerspectiveTest27";
+        final String pathExpectedResult = "org/uberfire/annotations/processors/expected/PerspectiveTest27.expected";
+
+        result.setExpectedCode(getExpectedSourceCode(pathExpectedResult));
+
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
+                getProcessorUnderTest(),
+                pathCompilationUnit);
+
+        assertSuccessfulCompilation(diagnostics);
+        assertNotNull(result.getActualCode());
+        assertNotNull(result.getExpectedCode());
+        assertEquals(result.getExpectedCode(),
+                     result.getActualCode());
+    }
+
+    @Test
+    public void testProfileAnnotationExtensionInTheActivity() throws FileNotFoundException {
+        final String pathCompilationUnit = "org/uberfire/annotations/processors/PerspectiveTest28";
+        final String pathExpectedResult = "org/uberfire/annotations/processors/expected/PerspectiveTest28.expected";
+
+        result.setExpectedCode(getExpectedSourceCode(pathExpectedResult));
+
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
+                getProcessorUnderTest(),
+                pathCompilationUnit);
+
+        assertSuccessfulCompilation(diagnostics);
+        assertNotNull(result.getActualCode());
+        assertNotNull(result.getExpectedCode());
+        assertEquals(result.getExpectedCode(),
+                     result.getActualCode());
+    }
+
     private void printDiagnostics(List<Diagnostic<? extends JavaFileObject>> diagnostics) {
         for (Diagnostic<? extends JavaFileObject> diagnostic : diagnostics) {
             System.out.println(diagnostic);

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchEditorProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchEditorProcessorTest.java
@@ -544,4 +544,22 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertEquals(result.getExpectedCode(),
                      result.getActualCode());
     }
+
+    @Test
+    public void testProfileInTheActivity() throws FileNotFoundException {
+        final String pathCompilationUnit = "org/uberfire/annotations/processors/WorkbenchEditorTest30";
+        final String pathExpectedResult = "org/uberfire/annotations/processors/expected/WorkbenchEditorTest30.expected";
+
+        result.setExpectedCode(getExpectedSourceCode(pathExpectedResult));
+
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
+                getProcessorUnderTest(),
+                pathCompilationUnit);
+
+        assertSuccessfulCompilation(diagnostics);
+        assertNotNull(result.getActualCode());
+        assertNotNull(result.getExpectedCode());
+        assertEquals(result.getExpectedCode(),
+                     result.getActualCode());
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchPopupProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchPopupProcessorTest.java
@@ -285,4 +285,22 @@ public class WorkbenchPopupProcessorTest extends AbstractProcessorTest {
         assertEquals(result.getExpectedCode(),
                      result.getActualCode());
     }
+
+    @Test
+    public void testProfileInTheActivity() throws FileNotFoundException {
+        final String pathCompilationUnit = "org/uberfire/annotations/processors/WorkbenchPopupTest15";
+        final String pathExpectedResult = "org/uberfire/annotations/processors/expected/WorkbenchPopupTest15.expected";
+
+        result.setExpectedCode(getExpectedSourceCode(pathExpectedResult));
+
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
+                getProcessorUnderTest(),
+                pathCompilationUnit);
+
+        assertSuccessfulCompilation(diagnostics);
+        assertNotNull(result.getActualCode());
+        assertNotNull(result.getExpectedCode());
+        assertEquals(result.getExpectedCode(),
+                     result.getActualCode());
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchScreenProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchScreenProcessorTest.java
@@ -632,4 +632,21 @@ public class WorkbenchScreenProcessorTest extends AbstractProcessorTest {
         assertEquals(result.getActualCode(),
                      result.getExpectedCode());
     }
+
+    @Test
+    public void testProfileInTheActivity() throws FileNotFoundException {
+        final String pathCompilationUnit = "org/uberfire/annotations/processors/WorkbenchScreenTest35";
+        final String pathExpectedResult = "org/uberfire/annotations/processors/expected/WorkbenchScreenTest35.expected";
+
+        result.setExpectedCode(getExpectedSourceCode(pathExpectedResult));
+
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
+                getProcessorUnderTest(),
+                pathCompilationUnit);
+        assertSuccessfulCompilation(diagnostics);
+        assertNotNull(result.getActualCode());
+        assertNotNull(result.getExpectedCode());
+        assertEquals(result.getActualCode(),
+                     result.getExpectedCode());
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchSplashScreenProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchSplashScreenProcessorTest.java
@@ -204,4 +204,22 @@ public class WorkbenchSplashScreenProcessorTest extends AbstractProcessorTest {
         assertEquals(result.getExpectedCode(),
                      result.getActualCode());
     }
+
+    @Test
+    public void testProfileInTheActivity() throws FileNotFoundException {
+        final String pathCompilationUnit = "org/uberfire/annotations/processors/WorkbenchSplashScreenTest11";
+        final String pathExpectedResult = "org/uberfire/annotations/processors/expected/WorkbenchSplashScreenTest11.expected";
+
+        result.setExpectedCode(getExpectedSourceCode(pathExpectedResult));
+
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
+                getProcessorUnderTest(),
+                pathCompilationUnit);
+
+        assertSuccessfulCompilation(diagnostics);
+        assertNotNull(result.getActualCode());
+        assertNotNull(result.getExpectedCode());
+        assertEquals(result.getExpectedCode(),
+                     result.getActualCode());
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/PerspectiveTest26.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/PerspectiveTest26.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import org.uberfire.client.annotations.Perspective;
+import org.uberfire.client.annotations.WorkbenchPerspective;
+import org.uberfire.commons.services.cdi.Profile;
+import org.uberfire.workbench.model.PerspectiveDefinition;
+
+@WorkbenchPerspective(identifier = "PerspectiveTest26")
+@Profile("test")
+public class PerspectiveTest26 {
+
+    @Perspective
+    public PerspectiveDefinition getPerspective() {
+        return null;
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/PerspectiveTest28.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/PerspectiveTest28.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import org.uberfire.client.annotations.Perspective;
+import org.uberfire.client.annotations.WorkbenchPerspective;
+import org.uberfire.workbench.model.PerspectiveDefinition;
+
+@WorkbenchPerspective(identifier = "PerspectiveTest28")
+@TestProfile
+public class PerspectiveTest28 {
+
+    @Perspective
+    public PerspectiveDefinition getPerspective() {
+        return null;
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/TestProfile.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/TestProfile.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.uberfire.commons.services.cdi.Profile;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, PACKAGE})
+@Profile("test")
+public @interface TestProfile {
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchEditorTest30.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchEditorTest30.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.SimplePanel;
+import org.uberfire.client.annotations.WorkbenchEditor;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.client.mvp.MyTestType;
+import org.uberfire.commons.services.cdi.Profile;
+
+@WorkbenchEditor(identifier = "test30", supportedTypes = { MyTestType.class })
+@Profile("test")
+public class WorkbenchEditorTest30 {
+
+    @WorkbenchPartView
+    public IsWidget getView() {
+        return new SimplePanel();
+    }
+
+    @WorkbenchPartTitle
+    public String getTitle() {
+        return "title";
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchPopupTest15.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchPopupTest15.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import com.google.gwt.user.client.ui.PopupPanel;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.client.annotations.WorkbenchPopup;
+import org.uberfire.commons.services.cdi.Profile;
+
+@WorkbenchPopup(identifier = "test15")
+@Profile("test")
+public class WorkbenchPopupTest15 {
+
+    @WorkbenchPartTitle
+    public String getTitle() {
+        return "title";
+    }
+
+    @WorkbenchPartView
+    public PopupPanel getView() {
+        return new PopupPanel();
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchScreenTest35.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchScreenTest35.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.SimplePanel;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.client.annotations.WorkbenchScreen;
+import org.uberfire.commons.services.cdi.Profile;
+
+@WorkbenchScreen(identifier = "test35")
+@Profile("test")
+public class WorkbenchScreenTest35 {
+
+    @WorkbenchPartView
+    public IsWidget getView() {
+        return new SimplePanel();
+    }
+
+    @WorkbenchPartTitle
+    public String getTitle() {
+        return "title";
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchSplashScreenTest11.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchSplashScreenTest11.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.SimplePanel;
+import org.uberfire.client.annotations.SplashFilter;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.client.annotations.WorkbenchSplashScreen;
+import org.uberfire.commons.services.cdi.Profile;
+import org.uberfire.workbench.model.SplashScreenFilter;
+
+@WorkbenchSplashScreen(identifier = "test11")
+@Profile("test")
+public class WorkbenchSplashScreenTest11 {
+
+    @WorkbenchPartView
+    public IsWidget getView() {
+        return new SimplePanel();
+    }
+
+    @WorkbenchPartTitle
+    public String getTitle() {
+        return "title";
+    }
+
+    @SplashFilter
+    public SplashScreenFilter getFilter() {
+        return null;
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest26.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest26.expected
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import javax.annotation.Generated;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import javax.inject.Named;
+import org.uberfire.workbench.model.PerspectiveDefinition;
+import org.uberfire.client.mvp.AbstractWorkbenchPerspectiveActivity;
+import org.uberfire.client.mvp.PlaceManager;
+
+import org.uberfire.mvp.PlaceRequest;
+
+import org.jboss.errai.ioc.client.api.EnabledByProperty;
+
+@Dependent
+@Generated("org.uberfire.annotations.processors.WorkbenchPerspectiveProcessor")
+@Named("PerspectiveTest26")
+@EnabledByProperty(value="org.uberfire.profile.active", matchValue="test", defaultValue="test")
+/*
+ * WARNING! This class is generated. Do not modify.
+ */
+public class PerspectiveTest26Activity extends AbstractWorkbenchPerspectiveActivity {
+
+    @Inject
+    private PerspectiveTest26 realPresenter;
+
+    @Inject
+    //Constructor injection for testing
+    public PerspectiveTest26Activity(final PlaceManager placeManager) {
+        super( placeManager );
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "PerspectiveTest26";
+    }
+
+    @Override
+    public PerspectiveDefinition getDefaultPerspectiveLayout() {
+        return realPresenter.getPerspective();
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest27.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest27.expected
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors.packagelevel;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import javax.annotation.Generated;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import javax.inject.Named;
+import org.uberfire.workbench.model.PerspectiveDefinition;
+import org.uberfire.client.mvp.AbstractWorkbenchPerspectiveActivity;
+import org.uberfire.client.mvp.PlaceManager;
+
+import org.uberfire.mvp.PlaceRequest;
+
+import org.jboss.errai.ioc.client.api.EnabledByProperty;
+
+@Dependent
+@Generated("org.uberfire.annotations.processors.WorkbenchPerspectiveProcessor")
+@Named("PerspectiveTest27")
+@EnabledByProperty(value="org.uberfire.profile.active", matchValue="test", defaultValue="test")
+/*
+ * WARNING! This class is generated. Do not modify.
+ */
+public class PerspectiveTest27Activity extends AbstractWorkbenchPerspectiveActivity {
+
+    @Inject
+    private PerspectiveTest27 realPresenter;
+
+    @Inject
+    //Constructor injection for testing
+    public PerspectiveTest27Activity(final PlaceManager placeManager) {
+        super( placeManager );
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "PerspectiveTest27";
+    }
+
+    @Override
+    public PerspectiveDefinition getDefaultPerspectiveLayout() {
+        return realPresenter.getPerspective();
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest28.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest28.expected
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import javax.annotation.Generated;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import javax.inject.Named;
+import org.uberfire.workbench.model.PerspectiveDefinition;
+import org.uberfire.client.mvp.AbstractWorkbenchPerspectiveActivity;
+import org.uberfire.client.mvp.PlaceManager;
+
+import org.uberfire.mvp.PlaceRequest;
+
+import org.jboss.errai.ioc.client.api.EnabledByProperty;
+
+@Dependent
+@Generated("org.uberfire.annotations.processors.WorkbenchPerspectiveProcessor")
+@Named("PerspectiveTest28")
+@EnabledByProperty(value="org.uberfire.profile.active", matchValue="test", defaultValue="test")
+/*
+ * WARNING! This class is generated. Do not modify.
+ */
+public class PerspectiveTest28Activity extends AbstractWorkbenchPerspectiveActivity {
+
+    @Inject
+    private PerspectiveTest28 realPresenter;
+
+    @Inject
+    //Constructor injection for testing
+    public PerspectiveTest28Activity(final PlaceManager placeManager) {
+        super( placeManager );
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "PerspectiveTest28";
+    }
+
+    @Override
+    public PerspectiveDefinition getDefaultPerspectiveLayout() {
+        return realPresenter.getPerspective();
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest30.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest30.expected
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import javax.annotation.Generated;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import javax.inject.Named;
+import org.uberfire.client.workbench.annotations.AssociatedResources;
+import org.uberfire.client.workbench.annotations.Priority;
+import org.uberfire.client.mvp.AbstractWorkbenchEditorActivity;
+import org.uberfire.client.mvp.PlaceManager;
+
+import org.uberfire.mvp.PlaceRequest;
+
+import org.uberfire.backend.vfs.ObservablePath;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+import org.jboss.errai.ioc.client.api.EnabledByProperty;
+
+@Dependent
+@Generated("org.uberfire.annotations.processors.WorkbenchEditorProcessor")
+@Named("test30")
+@AssociatedResources({
+    org.uberfire.client.mvp.MyTestType.class
+})
+
+@Priority(0)
+@EnabledByProperty(value="org.uberfire.profile.active", matchValue="test", defaultValue="test")
+/*
+ * WARNING! This class is generated. Do not modify.
+ */
+public class WorkbenchEditorTest30Activity extends AbstractWorkbenchEditorActivity {
+
+    @Inject
+    private WorkbenchEditorTest30 realPresenter;
+
+    @Inject
+    //Constructor injection for testing
+    public WorkbenchEditorTest30Activity(final PlaceManager placeManager) {
+        super( placeManager );
+    }
+
+    @Override
+    public String getTitle() {
+        return realPresenter.getTitle();
+    }
+
+    @Override
+    public IsWidget getWidget() {
+        return realPresenter.getView();
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "test30";
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest15.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest15.expected
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import javax.annotation.Generated;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import com.google.gwt.user.client.ui.InlineLabel;
+
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.mvp.AbstractPopupActivity;
+import org.uberfire.client.workbench.widgets.popup.PopupView;
+import javax.inject.Named;
+import org.uberfire.mvp.PlaceRequest;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+import org.jboss.errai.ioc.client.api.EnabledByProperty;
+
+@Dependent
+@Generated("org.uberfire.annotations.processors.WorkbenchPopupProcessor")
+@Named("test15")
+@EnabledByProperty(value="org.uberfire.profile.active", matchValue="test", defaultValue="test")
+/*
+ * WARNING! This class is generated. Do not modify.
+ */
+public class WorkbenchPopupTest15Activity extends AbstractPopupActivity {
+
+    @Inject
+    private WorkbenchPopupTest15 realPresenter;
+
+    @Inject
+    //Constructor injection for testing
+    public WorkbenchPopupTest15Activity( final PlaceManager placeManager, final PopupView view ) {
+        super( placeManager, view );
+    }
+
+    @Override
+    public String getTitle() {
+        return realPresenter.getTitle();
+    }
+
+    @Override
+    public IsWidget getWidget() {
+        return realPresenter.getView();
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "test15";
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest35.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest35.expected
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import javax.annotation.Generated;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import com.google.gwt.user.client.ui.InlineLabel;
+
+import javax.inject.Named;
+import org.uberfire.client.mvp.AbstractWorkbenchScreenActivity;
+import org.uberfire.client.mvp.PlaceManager;
+
+import org.uberfire.mvp.PlaceRequest;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+import org.jboss.errai.ioc.client.api.EnabledByProperty;
+
+@Dependent
+@Generated("org.uberfire.annotations.processors.WorkbenchScreenProcessor")
+@Named("test35")
+@EnabledByProperty(value="org.uberfire.profile.active", matchValue="test", defaultValue="test")
+/*
+ * WARNING! This class is generated. Do not modify.
+ */
+public class WorkbenchScreenTest35Activity extends AbstractWorkbenchScreenActivity {
+
+    @Inject
+    private WorkbenchScreenTest35 realPresenter;
+
+    @Inject
+    //Constructor injection for testing
+    public WorkbenchScreenTest35Activity(final PlaceManager placeManager) {
+        super( placeManager );
+    }
+
+    @Override
+    public String getTitle() {
+        return realPresenter.getTitle();
+    }
+
+    @Override
+    public IsWidget getWidget() {
+        return realPresenter.getView();
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "test35";
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchSplashScreenTest11.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchSplashScreenTest11.expected
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2012 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import javax.annotation.Generated;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import com.google.gwt.user.client.ui.InlineLabel;
+
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.mvp.AbstractSplashScreenActivity;
+import org.uberfire.client.workbench.widgets.splash.SplashView;
+import javax.inject.Named;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.model.SplashScreenFilter;
+import org.uberfire.client.mvp.IsSplashScreen;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+import org.jboss.errai.ioc.client.api.EnabledByProperty;
+
+@ApplicationScoped
+@Generated("org.uberfire.annotations.processors.WorkbenchSplashScreenProcessor")
+@Named("test11")
+@IsSplashScreen
+@EnabledByProperty(value="org.uberfire.profile.active", matchValue="test", defaultValue="test")
+/*
+ * WARNING! This class is generated. Do not modify.
+ */
+public class WorkbenchSplashScreenTest11Activity extends AbstractSplashScreenActivity {
+
+    @Inject
+    private WorkbenchSplashScreenTest11 realPresenter;
+
+    @Inject
+    //Constructor injection for testing
+    public WorkbenchSplashScreenTest11Activity( final PlaceManager placeManager, final SplashView view ) {
+        super( placeManager, view );
+    }
+
+    @Override
+    public String getTitle() {
+        return realPresenter.getTitle();
+    }
+
+    @Override
+    public IsWidget getWidget() {
+        return realPresenter.getView();
+    }
+
+    @Override
+    public SplashScreenFilter getFilter() {
+        return realPresenter.getFilter();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "test11";
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/packagelevel/PerspectiveTest27.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/packagelevel/PerspectiveTest27.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.annotations.processors.packagelevel;
+
+import org.uberfire.client.annotations.Perspective;
+import org.uberfire.client.annotations.WorkbenchPerspective;
+import org.uberfire.commons.services.cdi.Profile;
+import org.uberfire.workbench.model.PerspectiveDefinition;
+
+@WorkbenchPerspective(identifier = "PerspectiveTest27")
+public class PerspectiveTest27 {
+
+    @Perspective
+    public PerspectiveDefinition getPerspective() {
+        return null;
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/packagelevel/package-info.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/packagelevel/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Profile("test")
+package org.uberfire.annotations.processors.packagelevel;
+
+import org.uberfire.commons.services.cdi.Profile;

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/EditorActivityGenerator.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/EditorActivityGenerator.java
@@ -112,6 +112,10 @@ public class EditorActivityGenerator extends AbstractGenerator {
         final String beanActivatorClass = GeneratorUtils.getBeanActivatorClassName(classElement,
                                                                                    processingEnvironment);
 
+        final String profile = GeneratorUtils.getProfile(classElement,
+                                                         packageElement,
+                                                         processingEnvironment);
+
         final ExecutableElement onStartupMethod = GeneratorUtils.getOnStartupMethodForEditors(classElement,
                                                                                               processingEnvironment);
 
@@ -228,6 +232,8 @@ public class EditorActivityGenerator extends AbstractGenerator {
             messager.printMessage(Kind.NOTE,
                                   "Qualifiers: " + String.join(", ",
                                                                qualifiers));
+            messager.printMessage(Kind.NOTE,
+                                  "Profile: " + profile);
         }
 
         //Validate getWidgetMethodName and isWidget
@@ -315,6 +321,8 @@ public class EditorActivityGenerator extends AbstractGenerator {
                  isDynamic);
         root.put("qualifiers",
                  qualifiers);
+        root.put("profile",
+                 profile);
 
         //Generate code
         final StringWriter sw = new StringWriter();

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/GeneratorUtils.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/GeneratorUtils.java
@@ -23,13 +23,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.inject.Qualifier;
-import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.AnnotationValue;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.Name;
-import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -45,9 +39,7 @@ import org.uberfire.annotations.processors.facades.BackendModule;
 import org.uberfire.annotations.processors.facades.ClientAPIModule;
 
 import static java.util.Collections.singletonList;
-import static org.uberfire.annotations.processors.facades.ClientAPIModule.OWNING_PERSPECTIVE;
-import static org.uberfire.annotations.processors.facades.ClientAPIModule.workbenchEditor;
-import static org.uberfire.annotations.processors.facades.ClientAPIModule.workbenchScreen;
+import static org.uberfire.annotations.processors.facades.ClientAPIModule.*;
 
 /**
  * Utilities for code generation
@@ -555,6 +547,27 @@ public class GeneratorUtils {
                                                 "value");
         }
         return null;
+    }
+
+    public static String getProfile(final TypeElement classElement,
+                                    final PackageElement packageElement,
+                                    final ProcessingEnvironment processingEnvironment) {
+        AnnotationMirror profileAnnotation = getAnnotation(processingEnvironment.getElementUtils(),
+                                                           classElement,
+                                                           APIModule.profile);
+        if (profileAnnotation == null) {
+            profileAnnotation = getAnnotation(processingEnvironment.getElementUtils(),
+                                              packageElement,
+                                              APIModule.profile);
+        }
+
+        if (profileAnnotation != null) {
+            return extractAnnotationStringValue(processingEnvironment.getElementUtils(),
+                                                profileAnnotation,
+                                                "value");
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -1153,6 +1166,15 @@ public class GeneratorUtils {
             if (annotationName.contentEquals(getQualifiedName(annotation))) {
                 return annotation;
             }
+
+            //Check for annotations within annotations
+            final DeclaredType annotationType = annotation.getAnnotationType();
+            for (AnnotationMirror annotationMirror : elementUtils.getAllAnnotationMirrors(annotationType.asElement())) {
+                if (annotationName.contentEquals(getQualifiedName(annotationMirror))) {
+                    return annotationMirror;
+                }
+            }
+
         }
         return null;
     }

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/PerspectiveActivityGenerator.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/PerspectiveActivityGenerator.java
@@ -67,6 +67,10 @@ public class PerspectiveActivityGenerator extends AbstractGenerator {
         final String beanActivatorClass = GeneratorUtils.getBeanActivatorClassName(classElement,
                                                                                    processingEnvironment);
 
+        final String profile = GeneratorUtils.getProfile(classElement,
+                                                         packageElement,
+                                                         processingEnvironment);
+
         final ExecutableElement onStartupMethod = GeneratorUtils.getOnStartupMethodForNonEditors(classElement,
                                                                                                  processingEnvironment);
 
@@ -127,6 +131,8 @@ public class PerspectiveActivityGenerator extends AbstractGenerator {
             messager.printMessage(Kind.NOTE,
                                   "Qualifiers: " + String.join(", ",
                                                                qualifiers));
+            messager.printMessage(Kind.NOTE,
+                                  "Profile: " + profile);
         }
 
         Map<String, Object> root = new HashMap<String, Object>();
@@ -192,6 +198,8 @@ public class PerspectiveActivityGenerator extends AbstractGenerator {
                  isDynamic);
         root.put("qualifiers",
                  qualifiers);
+        root.put("profile",
+                 profile);
 
         //Generate code
         final StringWriter sw = new StringWriter();

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/PopupActivityGenerator.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/PopupActivityGenerator.java
@@ -62,6 +62,10 @@ public class PopupActivityGenerator extends AbstractGenerator {
         final String beanActivatorClass = GeneratorUtils.getBeanActivatorClassName(classElement,
                                                                                    processingEnvironment);
 
+        final String profile = GeneratorUtils.getProfile(classElement,
+                                                         packageElement,
+                                                         processingEnvironment);
+
         final ExecutableElement onStartupMethod = GeneratorUtils.getOnStartupMethodForNonEditors(classElement,
                                                                                                  processingEnvironment);
 
@@ -136,6 +140,8 @@ public class PopupActivityGenerator extends AbstractGenerator {
             messager.printMessage(Kind.NOTE,
                                   "Qualifiers: " + String.join(", ",
                                                                qualifiers));
+            messager.printMessage(Kind.NOTE,
+                                  "Profile: " + profile);
         }
 
         //Validate getWidgetMethodName and isWidget
@@ -194,6 +200,8 @@ public class PopupActivityGenerator extends AbstractGenerator {
                  hasUberView);
         root.put("qualifiers",
                  qualifiers);
+        root.put("profile",
+                 profile);
 
         //Generate code
         final StringWriter sw = new StringWriter();

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/ScreenActivityGenerator.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/ScreenActivityGenerator.java
@@ -92,6 +92,10 @@ public class ScreenActivityGenerator extends AbstractGenerator {
         final String beanActivatorClass = GeneratorUtils.getBeanActivatorClassName(classElement,
                                                                                    processingEnvironment);
 
+        final String profile = GeneratorUtils.getProfile(classElement,
+                                                         packageElement,
+                                                         processingEnvironment);
+
         final ExecutableElement onStartupMethod = GeneratorUtils.getOnStartupMethodForNonEditors(classElement,
                                                                                                  processingEnvironment);
 
@@ -216,6 +220,8 @@ public class ScreenActivityGenerator extends AbstractGenerator {
             messager.printMessage(Kind.NOTE,
                                   "Qualifiers: " + String.join(", ",
                                                                qualifiers));
+            messager.printMessage(Kind.NOTE,
+                                  "Profile: " + profile);
         }
 
         //Validate getWidgetMethodName and isWidget
@@ -300,6 +306,8 @@ public class ScreenActivityGenerator extends AbstractGenerator {
                  isDynamic);
         root.put("qualifiers",
                  qualifiers);
+        root.put("profile",
+                 profile);
 
         //Generate code
         final StringWriter sw = new StringWriter();

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/SplashScreenActivityGenerator.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/SplashScreenActivityGenerator.java
@@ -63,6 +63,10 @@ public class SplashScreenActivityGenerator extends AbstractGenerator {
         final String beanActivatorClass = GeneratorUtils.getBeanActivatorClassName(classElement,
                                                                                    processingEnvironment);
 
+        final String profile = GeneratorUtils.getProfile(classElement,
+                                                         packageElement,
+                                                         processingEnvironment);
+
         final ExecutableElement onStartupMethod = GeneratorUtils.getOnStartupMethodForNonEditors(classElement,
                                                                                                  processingEnvironment);
 
@@ -146,6 +150,8 @@ public class SplashScreenActivityGenerator extends AbstractGenerator {
             messager.printMessage(Kind.NOTE,
                                   "Qualifiers: " + String.join(", ",
                                                                qualifiers));
+            messager.printMessage(Kind.NOTE,
+                                  "Profile: " + profile);
         }
 
         //Validate getWidgetMethodName and isWidget
@@ -214,6 +220,8 @@ public class SplashScreenActivityGenerator extends AbstractGenerator {
                  getBodyHeightMethodName);
         root.put("qualifiers",
                  qualifiers);
+        root.put("profile",
+                 profile);
 
         //Generate code
         final StringWriter sw = new StringWriter();

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/facades/APIModule.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/facades/APIModule.java
@@ -37,6 +37,8 @@ public class APIModule {
     public static final String onStartup = "org.uberfire.lifecycle.OnStartup";
     public static final String onContextAttach = "org.uberfire.lifecycle.OnContextAttach";
     public static final String activatedBy = "org.jboss.errai.ioc.client.api.ActivatedBy";
+    public static final String profile = "org.uberfire.commons.services.cdi.Profile";
+
     private APIModule() {
     }
 

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityEditor.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityEditor.ftl
@@ -72,6 +72,10 @@ import jsinterop.annotations.JsType;
 import org.jboss.errai.ioc.client.api.Shared;
 
 </#if>
+<#if profile??>
+import org.jboss.errai.ioc.client.api.EnabledByProperty;
+
+</#if>
 @Dependent
 @Generated("org.uberfire.annotations.processors.WorkbenchEditorProcessor")
 @Named("${identifier}")
@@ -84,6 +88,9 @@ ${associatedResources}
 </#if>
 <#if isDynamic>
 @JsType
+</#if>
+<#if profile??>
+@EnabledByProperty(value="org.uberfire.profile.active", matchValue="${profile}", defaultValue="${profile}")
 </#if>
 <#list qualifiers as qualifier>
 ${qualifier}

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityScreen.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityScreen.ftl
@@ -70,6 +70,10 @@ import jsinterop.annotations.JsType;
 import org.jboss.errai.ioc.client.api.Shared;
 
 </#if>
+<#if profile??>
+import org.jboss.errai.ioc.client.api.EnabledByProperty;
+
+</#if>
 @Dependent
 @Generated("org.uberfire.annotations.processors.WorkbenchScreenProcessor")
 @Named("${identifier}")
@@ -78,6 +82,9 @@ import org.jboss.errai.ioc.client.api.Shared;
 </#if>
 <#if isDynamic>
 @JsType
+</#if>
+<#if profile??>
+@EnabledByProperty(value="org.uberfire.profile.active", matchValue="${profile}", defaultValue="${profile}")
 </#if>
 <#list qualifiers as qualifier>
 ${qualifier}

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/perspective.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/perspective.ftl
@@ -68,6 +68,10 @@ import jsinterop.annotations.JsType;
 import org.jboss.errai.ioc.client.api.Shared;
 
 </#if>
+<#if profile??>
+import org.jboss.errai.ioc.client.api.EnabledByProperty;
+
+</#if>
 @Dependent
 @Generated("org.uberfire.annotations.processors.WorkbenchPerspectiveProcessor")
 @Named("${identifier}")
@@ -76,6 +80,9 @@ import org.jboss.errai.ioc.client.api.Shared;
 </#if>
 <#if isDynamic>
 @JsType
+</#if>
+<#if profile??>
+@EnabledByProperty(value="org.uberfire.profile.active", matchValue="${profile}", defaultValue="${profile}")
 </#if>
 <#list qualifiers as qualifier>
 ${qualifier}

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/popupScreen.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/popupScreen.ftl
@@ -45,11 +45,18 @@ import com.google.gwt.user.client.ui.IsWidget;
 import org.jboss.errai.ioc.client.api.ActivatedBy;
 
 </#if>
+<#if profile??>
+import org.jboss.errai.ioc.client.api.EnabledByProperty;
+
+</#if>
 @Dependent
 @Generated("org.uberfire.annotations.processors.WorkbenchPopupProcessor")
 @Named("${identifier}")
 <#if beanActivatorClass??>
 @ActivatedBy(${beanActivatorClass}.class)
+</#if>
+<#if profile??>
+@EnabledByProperty(value="org.uberfire.profile.active", matchValue="${profile}", defaultValue="${profile}")
 </#if>
 <#list qualifiers as qualifier>
 ${qualifier}

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/splashScreen.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/splashScreen.ftl
@@ -43,12 +43,19 @@ import org.uberfire.client.mvp.IsSplashScreen;
 
 import com.google.gwt.user.client.ui.IsWidget;
 
+<#if profile??>
+import org.jboss.errai.ioc.client.api.EnabledByProperty;
+
+</#if>
 @ApplicationScoped
 @Generated("org.uberfire.annotations.processors.WorkbenchSplashScreenProcessor")
 @Named("${identifier}")
 @IsSplashScreen
 <#if beanActivatorClass??>
 @ActivatedBy(${beanActivatorClass}.class)
+</#if>
+<#if profile??>
+@EnabledByProperty(value="org.uberfire.profile.active", matchValue="${profile}", defaultValue="${profile}")
 </#if>
 <#list qualifiers as qualifier>
 ${qualifier}


### PR DESCRIPTION
 New API that switches CDI beans on/off based on the active profile (org.uberfire.profile.active system property).
 If no profile is defined at all, all beans still active.
 Once a profile is active, only the beans for the current profile remain available for CDI.
 Client side code for screens, perspectives, editors, etc is also filtered using Errai's `@EnabledByProperty`