### PR TITLE
[1.2.x] AF-582: [Wires Grids] Panning canvas when in Pinned Mode should not move grid

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandler.java
@@ -145,10 +145,12 @@ public class GridWidgetDnDMouseMoveHandler implements NodeMouseMoveHandler {
                                     cx);
             }
 
-            //If over Grid but no operation has been identified default to Grid dragging
-            if (state.getActiveGridWidget() == null) {
-                state.setActiveGridWidget(gridWidget);
-                state.setOperation(GridWidgetDnDHandlersState.GridWidgetHandlersOperation.GRID_MOVE_PENDING);
+            //If over Grid but no operation has been identified default to Grid dragging; when unpinned
+            if (!layer.isGridPinned()) {
+                if (state.getActiveGridWidget() == null) {
+                    state.setActiveGridWidget(gridWidget);
+                    state.setOperation(GridWidgetDnDHandlersState.GridWidgetHandlersOperation.GRID_MOVE_PENDING);
+                }
             }
         }
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/dnd/GridWidgetDnDMouseMoveHandlerTest.java
@@ -226,6 +226,7 @@ public class GridWidgetDnDMouseMoveHandlerTest {
         when(layer.getGridWidgets()).thenReturn(new HashSet<GridWidget>() {{
             add(gridWidget);
         }});
+
         //This location is top-left of the GridWidget; not within a column move/resize or row move hot-spot
         when(event.getX()).thenReturn(100);
         when(event.getY()).thenReturn(100);
@@ -253,6 +254,30 @@ public class GridWidgetDnDMouseMoveHandlerTest {
                times(1)).setActiveGridWidget(eq(gridWidget));
         verify(state,
                times(1)).setOperation(eq(GridWidgetHandlersOperation.GRID_MOVE_PENDING));
+    }
+
+    @Test
+    public void findMovableGridWhenNoColumnOrRowOperationIsDetectedAndGridIsPinned() {
+        when(state.getOperation()).thenReturn(GridWidgetHandlersOperation.NONE);
+        when(gridWidget.isVisible()).thenReturn(true);
+        when(layer.getGridWidgets()).thenReturn(new HashSet<GridWidget>() {{
+            add(gridWidget);
+        }});
+        when(layer.isGridPinned()).thenReturn(true);
+
+        //This location is top-left of the GridWidget; not within a column move/resize or row move hot-spot
+        when(event.getX()).thenReturn(100);
+        when(event.getY()).thenReturn(100);
+
+        handler.onNodeMouseMove(event);
+
+        verify(handler,
+               times(1)).findGridColumn(eq(event));
+
+        verify(state,
+               never()).setActiveGridWidget(any(GridWidget.class));
+        verify(state,
+               times(1)).setOperation(eq(GridWidgetHandlersOperation.NONE));
     }
 
     @Test


### PR DESCRIPTION
See https://issues.jboss.org/browse/AF-582

This is the corollary of https://github.com/AppFormer/uberfire/pull/792 for 1.2.x (7.2.x)

(cherry picked from commit e193e0c985c89a6c9336488d986bc82fd7cdab10)