### PR TITLE
Remove 'bundle' packaging where not needed

### DIFF
--- a/uberfire-io/pom.xml
+++ b/uberfire-io/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>uberfire-io</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>UberFire I/O</name>
   <description>
@@ -89,28 +89,5 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>org.uberfire.io</Bundle-SymbolicName>
-            <Import-Package>
-              !org.uberfire.io,
-              *
-            </Import-Package>
-            <Private-Package></Private-Package>
-            <Export-Package>
-              org.uberfire.io*
-            </Export-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-
-    </plugins>
-  </build>
 
 </project>

--- a/uberfire-nio2-backport/uberfire-nio2-model/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-model/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <artifactId>uberfire-nio2-model</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Uberfire NIO.2 :: Model</name>
   <description>Uberfire NIO.2 :: Model</description>
@@ -51,27 +51,5 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Bundle-SymbolicName>org.uberfire.java.nio</Bundle-SymbolicName>
-            <Import-Package>
-              *
-            </Import-Package>
-            <Private-Package></Private-Package>
-            <Export-Package>
-              *
-            </Export-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-    </plugins>
-
-  </build>
 
 </project>


### PR DESCRIPTION
The 'bundle' packaging is only needed when using the artifacts in OSGi
containers. None of the touched modules is being used in that way.