### PR TITLE
Upgrade freemarker to 2.3.26.jbossorg-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,8 @@
     <!-- JGIT 4.4.1.201607150455-r override can be removed once we use IP BOM which includes https://github.com/jboss-integration/jboss-integration-platform-bom/pull/327 -->
     <version.org.eclipse.jgit>4.8.0.201706111038-r</version.org.eclipse.jgit>
     <version.org.apache.sshd>1.6.0</version.org.apache.sshd>
-
+    <!-- Custom Freemarker build with workaround for random concurrent access issue (annotation processors). See AF-600 for more info.-->
+    <version.org.freemarker>2.3.26.jbossorg-1</version.org.freemarker>
     <version.org.jboss.errai>4.1.0-SNAPSHOT</version.org.jboss.errai>
     <version.org.webjars.bower.org.patternfly>3.18.1</version.org.webjars.bower.org.patternfly>
     <version.org.webjars.bower.google-code-prettify>1.0.4</version.org.webjars.bower.google-code-prettify>


### PR DESCRIPTION
As far as I have been able to test, this fixes the random compilation errors with annotation processors (AF-600). The disadvantage is that we are now using "custom" version (even if with just trivial changes). I am planning to propose the same workaround for the freemarker upstream, but at this point I am not sure it would be accepted since it is really is just a workaround.

This custom version is present in the JBoss.org repo and as such should not be pushed (and won't be) pushed into Maven Central. However, that should not really be a problem as we hardcode the jboss.org repo into our poms anyway.

@porcelli, @ederign please take a look and let me know what you think.