### PR TITLE
[7.3.x] GUVNOR-3198: [Guided Decision Table] Visual indication where the current view of Decision Table is located

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/demo/WiresGridsDemoViewImpl.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/demo/WiresGridsDemoViewImpl.java
@@ -161,6 +161,7 @@ public class WiresGridsDemoViewImpl extends Composite implements WiresGridsDemoV
     @Override
     public void refresh() {
         gridLayer.batch();
+        gridPanel.refreshScrollPosition();
     }
 
     @Override
@@ -202,6 +203,7 @@ public class WiresGridsDemoViewImpl extends Composite implements WiresGridsDemoV
 
         gridPanel.getViewport().setTransform(transform);
         gridPanel.getViewport().batch();
+        gridPanel.refreshScrollPosition();
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetEnterPinnedModeAnimation.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetEnterPinnedModeAnimation.java
@@ -15,6 +15,7 @@
  */
 package org.uberfire.ext.wires.core.grids.client.widget.grid.animation;
 
+import java.util.List;
 import java.util.Set;
 
 import com.ait.lienzo.client.core.animation.AnimationTweener;
@@ -38,7 +39,8 @@ public class GridWidgetEnterPinnedModeAnimation extends TimedAnimation {
     public GridWidgetEnterPinnedModeAnimation(final GridWidget gridWidget,
                                               final Set<GridWidget> gridWidgets,
                                               final Set<IPrimitive<?>> gridWidgetConnectors,
-                                              final Command onStartCommand) {
+                                              final Command onStartCommand,
+                                              final List<Command> onEnterPinnedModeCommands) {
         super(500,
               new IAnimationCallback() {
 
@@ -105,6 +107,8 @@ public class GridWidgetEnterPinnedModeAnimation extends TimedAnimation {
                       }
                       gridWidget.getLayer().setListening(true);
                       gridWidget.getLayer().batch();
+
+                      onEnterPinnedModeCommands.forEach(Command::execute);
                   }
 
                   private Point2D getViewportTranslation() {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetExitPinnedModeAnimation.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetExitPinnedModeAnimation.java
@@ -15,6 +15,7 @@
  */
 package org.uberfire.ext.wires.core.grids.client.widget.grid.animation;
 
+import java.util.List;
 import java.util.Set;
 
 import com.ait.lienzo.client.core.animation.AnimationTweener;
@@ -39,7 +40,8 @@ public class GridWidgetExitPinnedModeAnimation extends TimedAnimation {
     public GridWidgetExitPinnedModeAnimation(final GridPinnedModeManager.PinnedContext state,
                                              final Set<GridWidget> gridWidgets,
                                              final Set<IPrimitive<?>> gridWidgetConnectors,
-                                             final Command onCompleteCommand) {
+                                             final Command onCompleteCommand,
+                                             final List<Command> onExitPinnedModeCommands) {
         super(500,
               new IAnimationCallback() {
 
@@ -106,10 +108,12 @@ public class GridWidgetExitPinnedModeAnimation extends TimedAnimation {
                   @Override
                   public void onClose(final IAnimation animation,
                                       final IAnimationHandle handle) {
-                      gridWidget.getLayer().setListening(true);
-                      gridWidget.getLayer().batch();
+                      state.getGridWidget().getLayer().setListening(true);
+                      state.getGridWidget().getLayer().batch();
 
                       onCompleteCommand.execute();
+
+                      onExitPinnedModeCommands.forEach(Command::execute);
                   }
 
                   private Point2D getViewportTranslation() {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/DefaultGridLayer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/DefaultGridLayer.java
@@ -438,6 +438,20 @@ public class DefaultGridLayer extends Layer implements GridLayer {
     }
 
     @Override
+    public void addOnEnterPinnedModeCommand(final Command command) {
+        getPinnedModeManager().addOnEnterPinnedModeCommand(command);
+    }
+
+    @Override
+    public void addOnExitPinnedModeCommand(final Command command) {
+        getPinnedModeManager().addOnExitPinnedModeCommand(command);
+    }
+
+    DefaultPinnedModeManager getPinnedModeManager() {
+        return pinnedModeManager;
+    }
+
+    @Override
     public Bounds getVisibleBounds() {
         updateVisibleBounds();
         return bounds;

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/GridPinnedModeManager.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/GridPinnedModeManager.java
@@ -57,6 +57,10 @@ public interface GridPinnedModeManager extends IsPinnedModeAware {
      */
     TransformMediator getDefaultTransformMediator();
 
+    void addOnEnterPinnedModeCommand(final Command command);
+
+    void addOnExitPinnedModeCommand(final Command command);
+
     /**
      * Container for the previous Viewport state; to support "unpinning" to revert to the previous Viewport transformation.
      */

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/DefaultPinnedModeManager.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/DefaultPinnedModeManager.java
@@ -15,7 +15,9 @@
  */
 package org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import com.ait.lienzo.client.core.mediator.IMediator;
@@ -39,9 +41,15 @@ public class DefaultPinnedModeManager implements GridPinnedModeManager {
 
     private final GridLayer gridLayer;
 
+    private final List<Command> onEnterPinnedModeCommands;
+
+    private final List<Command> onExitPinnedModeCommands;
+
     private PinnedContext context = null;
 
     public DefaultPinnedModeManager(final GridLayer gridLayer) {
+        this.onEnterPinnedModeCommands = new ArrayList<>();
+        this.onExitPinnedModeCommands = new ArrayList<>();
         this.gridLayer = PortablePreconditions.checkNotNull("gridLayer",
                                                             gridLayer);
     }
@@ -84,7 +92,8 @@ public class DefaultPinnedModeManager implements GridPinnedModeManager {
         final GridWidgetEnterPinnedModeAnimation enterAnimation = new GridWidgetEnterPinnedModeAnimation(gridWidget,
                                                                                                          gridWidgetsToFadeFromView,
                                                                                                          gridWidgetConnectorsToFadeFromView,
-                                                                                                         onStartCommand);
+                                                                                                         onStartCommand,
+                                                                                                         onEnterPinnedModeCommands);
         enterAnimation.run();
     }
 
@@ -113,7 +122,8 @@ public class DefaultPinnedModeManager implements GridPinnedModeManager {
         final GridWidgetExitPinnedModeAnimation exitAnimation = new GridWidgetExitPinnedModeAnimation(context,
                                                                                                       gridWidgetsToFadeIntoView,
                                                                                                       gridWidgetConnectorsToFadeIntoView,
-                                                                                                      onCompleteCommand);
+                                                                                                      onCompleteCommand,
+                                                                                                      onExitPinnedModeCommands);
         exitAnimation.run();
     }
 
@@ -176,5 +186,15 @@ public class DefaultPinnedModeManager implements GridPinnedModeManager {
     @Override
     public TransformMediator getDefaultTransformMediator() {
         return gridLayer.getDefaultTransformMediator();
+    }
+
+    @Override
+    public void addOnEnterPinnedModeCommand(final Command command) {
+        onEnterPinnedModeCommands.add(command);
+    }
+
+    @Override
+    public void addOnExitPinnedModeCommand(final Command command) {
+        onExitPinnedModeCommands.add(command);
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/RestrictedMousePanMediator.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/RestrictedMousePanMediator.java
@@ -37,7 +37,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.TransformMe
  */
 public class RestrictedMousePanMediator extends AbstractMediator {
 
-    private final GridLayer gridLayer;
+    private GridLayer gridLayer;
 
     private TransformMediator transformMediator;
 
@@ -49,6 +49,9 @@ public class RestrictedMousePanMediator extends AbstractMediator {
 
     public RestrictedMousePanMediator(final GridLayer gridLayer) {
         this.gridLayer = gridLayer;
+    }
+
+    protected RestrictedMousePanMediator() {
     }
 
     public boolean isDragging() {
@@ -70,8 +73,15 @@ public class RestrictedMousePanMediator extends AbstractMediator {
     }
 
     protected void setCursor(final Style.Cursor cursor) {
-        final Viewport viewport = gridLayer.getViewport();
-        viewport.getElement().getStyle().setCursor(cursor);
+        getLayerViewport().getElement().getStyle().setCursor(cursor);
+    }
+
+    protected Viewport getLayerViewport() {
+        return getGridLayer().getViewport();
+    }
+
+    GridLayer getGridLayer() {
+        return gridLayer;
     }
 
     @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollBars.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollBars.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.scrollbars;
+
+import com.google.gwt.user.client.ui.Panel;
+
+/*
+ * Represents browser scrollbars in the Grid Lienzo context,
+ * providing an API to get/set their position.
+ */
+
+class GridLienzoScrollBars {
+
+    private final GridLienzoScrollHandler gridLienzoScrollHandler;
+
+    GridLienzoScrollBars(final GridLienzoScrollHandler gridLienzoScrollHandler) {
+        this.gridLienzoScrollHandler = gridLienzoScrollHandler;
+    }
+
+    Double getHorizontalScrollPosition() {
+
+        final Integer scrollLeft = panel().getElement().getScrollLeft();
+        final Integer scrollWidth = panel().getElement().getScrollWidth();
+        final Integer clientWidth = panel().getElement().getClientWidth();
+        final Integer level = scrollWidth - clientWidth;
+
+        return level == 0 ? 0d : 100d * scrollLeft / level;
+    }
+
+    void setHorizontalScrollPosition(final Double percentage) {
+
+        final Integer scrollWidth = panel().getElement().getScrollWidth();
+        final Integer clientWidth = panel().getElement().getClientWidth();
+        final Integer max = scrollWidth - clientWidth;
+
+        setScrollLeft((int) ((max * percentage) / 100));
+    }
+
+    Double getVerticalScrollPosition() {
+
+        final Integer scrollTop = panel().getElement().getScrollTop();
+        final Integer scrollHeight = panel().getElement().getScrollHeight();
+        final Integer clientHeight = panel().getElement().getClientHeight();
+        final Integer level = scrollHeight - clientHeight;
+
+        return level == 0 ? 0d : 100d * scrollTop / level;
+    }
+
+    void setVerticalScrollPosition(final Double percentage) {
+
+        final Integer scrollHeight = panel().getElement().getScrollHeight();
+        final Integer clientHeight = panel().getElement().getClientHeight();
+        final Integer max = scrollHeight - clientHeight;
+
+        setScrollTop((int) ((max * percentage) / 100));
+    }
+
+    void setScrollTop(final Integer scrollTop) {
+        panel().getElement().setScrollTop(scrollTop);
+    }
+
+    void setScrollLeft(final Integer scrollLeft) {
+        panel().getElement().setScrollLeft(scrollLeft);
+    }
+
+    Panel panel() {
+        return gridLienzoScrollHandler.getMainPanel();
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollBounds.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollBounds.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.scrollbars;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import com.ait.lienzo.client.core.shape.IDrawable;
+import com.ait.lienzo.client.core.shape.IPrimitive;
+import com.ait.lienzo.client.core.shape.Viewport;
+import org.uberfire.ext.wires.core.grids.client.model.Bounds;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+
+/*
+ * Represents the Grid Lienzo bounds in the scrollbars context.
+ */
+
+class GridLienzoScrollBounds {
+
+    private static final Double DEFAULT_VALUE = 0D;
+
+    private final GridLienzoScrollHandler gridLienzoScrollHandler;
+
+    private Bounds defaultBounds;
+
+    GridLienzoScrollBounds(final GridLienzoScrollHandler GridLienzoScrollHandler) {
+        this.gridLienzoScrollHandler = GridLienzoScrollHandler;
+    }
+
+    Double maxBoundX() {
+
+        final List<Double> boundsValues =
+                getVisibleGridWidgets()
+                        .map(gridWidget -> gridWidget.getX() + gridWidget.getWidth())
+                        .collect(Collectors.toList());
+
+        addExtraBounds(boundsValues,
+                       bounds -> bounds.getX() + bounds.getWidth());
+
+        return maxValue(boundsValues);
+    }
+
+    Double maxBoundY() {
+
+        final List<Double> boundsValues =
+                getVisibleGridWidgets()
+                        .map(gridWidget -> gridWidget.getY() + gridWidget.getHeight())
+                        .collect(Collectors.toList());
+
+        addExtraBounds(boundsValues,
+                       bounds -> bounds.getY() + bounds.getHeight());
+
+        return maxValue(boundsValues);
+    }
+
+    Double minBoundX() {
+
+        final List<Double> boundsValues =
+                getVisibleGridWidgets()
+                        .map(IPrimitive::getX)
+                        .collect(Collectors.toList());
+
+        addExtraBounds(boundsValues,
+                       Bounds::getX);
+
+        return minValue(boundsValues);
+    }
+
+    Double minBoundY() {
+
+        final List<Double> boundsValues =
+                getVisibleGridWidgets()
+                        .map(IPrimitive::getY)
+                        .collect(Collectors.toList());
+
+        addExtraBounds(boundsValues,
+                       Bounds::getY);
+
+        return minValue(boundsValues);
+    }
+
+    Stream<GridWidget> getVisibleGridWidgets() {
+        return getGridWidgets()
+                .stream()
+                .filter(IDrawable::isVisible);
+    }
+
+    private double maxValue(final List<Double> boundsValues) {
+        return boundsValues.stream().reduce(Double::max).orElse(DEFAULT_VALUE);
+    }
+
+    private double minValue(final List<Double> boundsValues) {
+        return boundsValues.stream().reduce(Double::min).orElse(DEFAULT_VALUE);
+    }
+
+    private void addExtraBounds(final List<Double> bounds,
+                                final Function<Bounds, Double> function) {
+        if (hasVisibleBounds()) {
+            bounds.add(function.apply(getVisibleBounds()));
+        }
+
+        if (hasDefaultBounds() && !isGridPinned()) {
+            bounds.add(function.apply(getDefaultBounds()));
+        }
+    }
+
+    Bounds getVisibleBounds() {
+        return getDefaultGridLayer().getVisibleBounds();
+    }
+
+    Boolean hasDefaultBounds() {
+        return Optional.ofNullable(getDefaultBounds()).isPresent();
+    }
+
+    Boolean hasVisibleBounds() {
+        final Viewport viewport = getDefaultGridLayer().getViewport();
+
+        return Optional.ofNullable(viewport).isPresent();
+    }
+
+    Bounds getDefaultBounds() {
+        return defaultBounds;
+    }
+
+    void setDefaultBounds(final Bounds defaultBounds) {
+        this.defaultBounds = defaultBounds;
+    }
+
+    DefaultGridLayer getDefaultGridLayer() {
+        return gridLienzoScrollHandler.getDefaultGridLayer();
+    }
+
+    Set<GridWidget> getGridWidgets() {
+        return getDefaultGridLayer().getGridWidgets();
+    }
+
+    private boolean isGridPinned() {
+        return getDefaultGridLayer().isGridPinned();
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandler.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.scrollbars;
+
+import java.util.Optional;
+
+import com.ait.lienzo.client.core.event.NodeMouseMoveEvent;
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.client.core.types.Transform;
+import com.ait.lienzo.client.widget.LienzoPanel;
+import com.google.gwt.event.dom.client.ScrollEvent;
+import com.google.gwt.event.dom.client.ScrollHandler;
+import com.google.gwt.user.client.ui.AbsolutePanel;
+import org.uberfire.ext.wires.core.grids.client.model.Bounds;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLienzoPanel;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
+
+/*
+ * Responsible for the setup and control of every scroll related event.
+ */
+
+public class GridLienzoScrollHandler {
+
+    private final GridLienzoPanel panel;
+
+    private final GridLienzoScrollBounds gridLienzoScrollBounds;
+
+    static final int DEFAULT_INTERNAL_SCROLL_HEIGHT = 1;
+
+    static final int DEFAULT_INTERNAL_SCROLL_WIDTH = 1;
+
+    private RestrictedMousePanMediator mousePanMediator;
+
+    public GridLienzoScrollHandler(final GridLienzoPanel panel) {
+        this.panel = panel;
+        this.gridLienzoScrollBounds = new GridLienzoScrollBounds(this);
+    }
+
+    public void init() {
+        setupGridLienzoScrollStyle();
+        setupScrollBarSynchronization();
+        setupMouseDragSynchronization();
+    }
+
+    public Integer scrollbarWidth() {
+        return getMainPanel().getElement().getOffsetWidth() - getMainPanel().getElement().getClientWidth();
+    }
+
+    public Integer scrollbarHeight() {
+        return getMainPanel().getElement().getOffsetHeight() - getMainPanel().getElement().getClientHeight();
+    }
+
+    void setupGridLienzoScrollStyle() {
+        gridLienzoScrollUI().setup();
+    }
+
+    GridLienzoScrollUI gridLienzoScrollUI() {
+        return new GridLienzoScrollUI(this);
+    }
+
+    void setupScrollBarSynchronization() {
+        getMainPanel().addDomHandler(onScroll(),
+                                     ScrollEvent.getType());
+        synchronizeScrollSize();
+    }
+
+    void setupMouseDragSynchronization() {
+
+        mousePanMediator = makeRestrictedMousePanMediator();
+
+        getLienzoPanel().getViewport().getMediators().push(mousePanMediator);
+    }
+
+    RestrictedMousePanMediator makeRestrictedMousePanMediator() {
+        return new RestrictedMousePanMediator() {
+            @Override
+            protected void onMouseMove(final NodeMouseMoveEvent event) {
+                refreshScrollPosition();
+            }
+
+            @Override
+            protected Viewport getLayerViewport() {
+                return getViewport();
+            }
+        };
+    }
+
+    ScrollHandler onScroll() {
+        return (ScrollEvent event) -> {
+            final Boolean mouseIsNotDragging = !getMousePanMediator().isDragging();
+
+            if (mouseIsNotDragging) {
+                updateGridLienzoPosition();
+            }
+        };
+    }
+
+    public void refreshScrollPosition() {
+
+        synchronizeScrollSize();
+
+        setScrollBarsPosition(scrollPosition().currentRelativeX(),
+                              scrollPosition().currentRelativeY());
+    }
+
+    void updateGridLienzoPosition() {
+
+        final Double percentageX = scrollBars().getHorizontalScrollPosition();
+        final Double percentageY = scrollBars().getVerticalScrollPosition();
+
+        final Double currentXPosition = scrollPosition().currentPositionX(percentageX);
+        final Double currentYPosition = scrollPosition().currentPositionY(percentageY);
+
+        updateGridLienzoTransform(currentXPosition,
+                                  currentYPosition);
+    }
+
+    void updateGridLienzoTransform(final Double currentXPosition,
+                                   final Double currentYPosition) {
+
+        final Transform oldTransform = getViewport().getTransform();
+        final Double dx = currentXPosition - (oldTransform.getTranslateX() / oldTransform.getScaleX());
+        final Double dy = currentYPosition - (oldTransform.getTranslateY() / oldTransform.getScaleY());
+
+        final Transform newTransform = oldTransform.copy().translate(dx,
+                                                                     dy);
+
+        getViewport().setTransform(newTransform);
+        getDefaultGridLayer().batch();
+    }
+
+    void synchronizeScrollSize() {
+        getInternalScrollPanel().setPixelSize(calculateInternalScrollPanelWidth(),
+                                              calculateInternalScrollPanelHeight());
+    }
+
+    Integer calculateInternalScrollPanelWidth() {
+        final Double absWidth = scrollBounds().maxBoundX() - scrollBounds().minBoundX();
+
+        if (getViewport() != null && scrollPosition().deltaX() != 0) {
+            final Double scaleX = getViewport().getTransform().getScaleX();
+            final Double width = absWidth * scaleX;
+
+            return width.intValue();
+        }
+
+        return DEFAULT_INTERNAL_SCROLL_WIDTH;
+    }
+
+    Integer calculateInternalScrollPanelHeight() {
+        final Double absHeight = scrollBounds().maxBoundY() - scrollBounds().minBoundY();
+
+        if (getViewport() != null && scrollPosition().deltaY() != 0) {
+            final Double scaleY = getViewport().getTransform().getScaleY();
+            final Double height = absHeight * scaleY;
+
+            return height.intValue();
+        }
+
+        return DEFAULT_INTERNAL_SCROLL_HEIGHT;
+    }
+
+    void setScrollBarsPosition(final Double xPercentage,
+                               final Double yPercentage) {
+
+        scrollBars().setHorizontalScrollPosition(xPercentage);
+        scrollBars().setVerticalScrollPosition(yPercentage);
+    }
+
+    RestrictedMousePanMediator getMousePanMediator() {
+        return mousePanMediator;
+    }
+
+    AbsolutePanel getMainPanel() {
+        return panel.getMainPanel();
+    }
+
+    AbsolutePanel getInternalScrollPanel() {
+        return panel.getInternalScrollPanel();
+    }
+
+    AbsolutePanel getDomElementContainer() {
+        return panel.getDomElementContainer();
+    }
+
+    LienzoPanel getLienzoPanel() {
+        return panel.getLienzoPanel();
+    }
+
+    DefaultGridLayer getDefaultGridLayer() {
+        return Optional.ofNullable(panel.getDefaultGridLayer()).orElse(emptyLayer());
+    }
+
+    Viewport getViewport() {
+        return getDefaultGridLayer().getViewport();
+    }
+
+    DefaultGridLayer emptyLayer() {
+        return new DefaultGridLayer();
+    }
+
+    GridLienzoScrollBars scrollBars() {
+        return new GridLienzoScrollBars(this);
+    }
+
+    GridLienzoScrollPosition scrollPosition() {
+        return new GridLienzoScrollPosition(this);
+    }
+
+    GridLienzoScrollBounds scrollBounds() {
+        return gridLienzoScrollBounds;
+    }
+
+    public void setBounds(final Bounds bounds) {
+        scrollBounds().setDefaultBounds(bounds);
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollPosition.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollPosition.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.scrollbars;
+
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.client.core.types.Transform;
+import org.uberfire.ext.wires.core.grids.client.model.Bounds;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+
+/*
+ * Converts the viewport coordinates to a proportional unit, in the Grid Lienzo scrollbars context.
+ */
+
+class GridLienzoScrollPosition {
+
+    private final GridLienzoScrollHandler gridLienzoScrollHandler;
+
+    GridLienzoScrollPosition(final GridLienzoScrollHandler gridLienzoScrollHandler) {
+        this.gridLienzoScrollHandler = gridLienzoScrollHandler;
+    }
+
+    Double currentRelativeX() {
+
+        final Double delta = deltaX();
+
+        return delta == 0d ? 0d : 100 * currentX() / delta;
+    }
+
+    Double currentRelativeY() {
+
+        final Double delta = deltaY();
+
+        return delta == 0d ? 0d : 100 * currentY() / delta;
+    }
+
+    Double currentPositionX(final Double level) {
+
+        final Double position = deltaX() * level / 100;
+
+        return -(bounds().minBoundX() + position);
+    }
+
+    Double currentPositionY(final Double level) {
+
+        final Double position = deltaY() * level / 100;
+
+        return -(bounds().minBoundY() + position);
+    }
+
+    Double deltaX() {
+        return bounds().maxBoundX() - bounds().minBoundX() - getVisibleBounds().getWidth();
+    }
+
+    Double deltaY() {
+        return bounds().maxBoundY() - bounds().minBoundY() - getVisibleBounds().getHeight();
+    }
+
+    private Double currentX() {
+        return -(getTransform().getTranslateX() / getTransform().getScaleX() + bounds().minBoundX());
+    }
+
+    private Double currentY() {
+        return -(getTransform().getTranslateY() / getTransform().getScaleY() + bounds().minBoundY());
+    }
+
+    Transform getTransform() {
+        final Viewport viewport = getDefaultGridLayer().getViewport();
+
+        return viewport.getTransform();
+    }
+
+    Bounds getVisibleBounds() {
+        return getDefaultGridLayer().getVisibleBounds();
+    }
+
+    GridLienzoScrollBounds bounds() {
+        return gridLienzoScrollHandler.scrollBounds();
+    }
+
+    private DefaultGridLayer getDefaultGridLayer() {
+        return gridLienzoScrollHandler.getDefaultGridLayer();
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollUI.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollUI.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.scrollbars;
+
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.ui.AbsolutePanel;
+import com.google.gwt.user.client.ui.Widget;
+
+/*
+ * Applies the scrollbar style in the Grid Lienzo panels.
+ */
+
+class GridLienzoScrollUI {
+
+    private final GridLienzoScrollHandler gridLienzoScrollHandler;
+
+    GridLienzoScrollUI(final GridLienzoScrollHandler gridLienzoScrollHandler) {
+        this.gridLienzoScrollHandler = gridLienzoScrollHandler;
+    }
+
+    void setup() {
+        applyMainPanelStyle();
+        applyMakeInternalScrollPanel();
+        applyDomElementContainerStyle();
+    }
+
+    void applyMainPanelStyle() {
+        style(getMainPanel()).setPosition(Style.Position.RELATIVE);
+        style(getMainPanel()).setOverflow(Style.Overflow.SCROLL);
+        style(getMainPanel()).setZIndex(1);
+    }
+
+    void applyMakeInternalScrollPanel() {
+        style(getInternalScrollPanel()).setPosition(Style.Position.ABSOLUTE);
+    }
+
+    void applyDomElementContainerStyle() {
+        style(getDomElementContainer()).setPosition(Style.Position.FIXED);
+    }
+
+    private AbsolutePanel getMainPanel() {
+        return gridLienzoScrollHandler.getMainPanel();
+    }
+
+    private AbsolutePanel getInternalScrollPanel() {
+        return gridLienzoScrollHandler.getInternalScrollPanel();
+    }
+
+    private AbsolutePanel getDomElementContainer() {
+        return gridLienzoScrollHandler.getDomElementContainer();
+    }
+
+    Style style(final Widget widget) {
+        return widget.getElement().getStyle();
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollable.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollable.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.scrollbars;
+
+import org.uberfire.ext.wires.core.grids.client.model.Bounds;
+
+public interface GridLienzoScrollable {
+
+    void updatePanelSize();
+
+    void refreshScrollPosition();
+
+    void setBounds(final Bounds bounds);
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetEnterPinnedModeAnimationTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetEnterPinnedModeAnimationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.grid.animation;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.ait.lienzo.client.core.shape.IPrimitive;
+import com.ait.lienzo.client.core.shape.Layer;
+import com.google.gwt.user.client.Command;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GridWidgetEnterPinnedModeAnimationTest {
+
+    @Mock
+    private Layer layer;
+
+    @Mock
+    private GridWidget gridWidget;
+
+    @Mock
+    private Command onStartCommand;
+
+    @Mock
+    private GridWidget widget;
+
+    @Mock
+    private IPrimitive<?> primitive;
+
+    @Mock
+    private Command command;
+
+    @Test
+    public void testOnClose() {
+
+        doReturn(layer).when(gridWidget).getLayer();
+
+        final Set<GridWidget> gridWidgets = new HashSet<GridWidget>() {{
+            add(widget);
+        }};
+        final Set<IPrimitive<?>> gridWidgetConnectors = new HashSet<IPrimitive<?>>() {{
+            add(primitive);
+        }};
+        final List<Command> onEnterPinnedModeCommands = new ArrayList<Command>() {{
+            add(command);
+        }};
+        final GridWidgetEnterPinnedModeAnimation animation = new GridWidgetEnterPinnedModeAnimation(gridWidget,
+                                                                                                    gridWidgets,
+                                                                                                    gridWidgetConnectors,
+                                                                                                    onStartCommand,
+                                                                                                    onEnterPinnedModeCommands);
+
+        animation.doClose();
+
+        verify(widget).setVisible(false);
+        verify(primitive).setVisible(false);
+        verify(layer).setListening(true);
+        verify(layer).batch();
+        verify(command).execute();
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetExitPinnedModeAnimationTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/animation/GridWidgetExitPinnedModeAnimationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.grid.animation;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.ait.lienzo.client.core.shape.IPrimitive;
+import com.ait.lienzo.client.core.shape.Layer;
+import com.google.gwt.user.client.Command;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.GridPinnedModeManager;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GridWidgetExitPinnedModeAnimationTest {
+
+    @Mock
+    private Layer layer;
+
+    @Mock
+    private GridWidget gridWidget;
+
+    @Mock
+    private GridPinnedModeManager.PinnedContext state;
+
+    @Mock
+    private Command onCompleteCommand;
+
+    @Mock
+    private Command command;
+
+    @Test
+    public void testOnClose() {
+
+        doReturn(layer).when(gridWidget).getLayer();
+        doReturn(gridWidget).when(state).getGridWidget();
+
+        final Set<GridWidget> gridWidgets = new HashSet<>();
+        final Set<IPrimitive<?>> gridWidgetConnectors = new HashSet<>();
+        final List<Command> onExitPinnedModeCommands = new ArrayList<Command>() {{
+            add(command);
+        }};
+        final GridWidgetExitPinnedModeAnimation animation = new GridWidgetExitPinnedModeAnimation(state,
+                                                                                                  gridWidgets,
+                                                                                                  gridWidgetConnectors,
+                                                                                                  onCompleteCommand,
+                                                                                                  onExitPinnedModeCommands);
+
+        animation.doClose();
+
+        verify(layer).setListening(true);
+        verify(layer).batch();
+        verify(onCompleteCommand).execute();
+        verify(command).execute();
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/DefaultGridLayerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/DefaultGridLayerTest.java
@@ -24,6 +24,7 @@ import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.types.Transform;
 import com.ait.lienzo.client.widget.LienzoPanel;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.user.client.Command;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +36,7 @@ import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.impl.BaseGridWidget;
 import org.uberfire.ext.wires.core.grids.client.widget.grid.renderers.grids.GridRenderer;
 import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.DefaultPinnedModeManager;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -222,6 +224,34 @@ public class DefaultGridLayerTest {
         gridLayer.refreshGridWidgetConnectors();
 
         checkConnectorsVisibility(false);
+    }
+
+    @Test
+    public void testAddOnEnterPinnedModeCommand() {
+
+        final DefaultGridLayer defaultGridLayer = spy(new DefaultGridLayer());
+        final DefaultPinnedModeManager defaultPinnedModeManager = mock(DefaultPinnedModeManager.class);
+        final Command command = mock(Command.class);
+
+        doReturn(defaultPinnedModeManager).when(defaultGridLayer).getPinnedModeManager();
+
+        defaultGridLayer.addOnEnterPinnedModeCommand(command);
+
+        verify(defaultPinnedModeManager).addOnEnterPinnedModeCommand(command);
+    }
+
+    @Test
+    public void testAddOnExitPinnedModeCommand() {
+
+        final DefaultGridLayer defaultGridLayer = spy(new DefaultGridLayer());
+        final DefaultPinnedModeManager defaultPinnedModeManager = mock(DefaultPinnedModeManager.class);
+        final Command command = mock(Command.class);
+
+        doReturn(defaultPinnedModeManager).when(defaultGridLayer).getPinnedModeManager();
+
+        defaultGridLayer.addOnExitPinnedModeCommand(command);
+
+        verify(defaultPinnedModeManager).addOnExitPinnedModeCommand(command);
     }
 
     private void checkConnectorsVisibility(final boolean isVisible) {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLienzoPanelTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLienzoPanelTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.layer.impl;
+
+import com.ait.lienzo.client.widget.LienzoPanel;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.event.dom.client.MouseUpEvent;
+import com.google.gwt.event.dom.client.MouseUpHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.ui.AbsolutePanel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.widget.scrollbars.GridLienzoScrollHandler;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class GridLienzoPanelTest {
+
+    @Mock
+    private AbsolutePanel mainPanel;
+
+    @Mock
+    private AbsolutePanel internalScrollPanel;
+
+    @Mock
+    private AbsolutePanel domElementContainer;
+
+    @Mock
+    private GridLienzoScrollHandler gridLienzoScrollHandler;
+
+    @Mock
+    private LienzoPanel lienzoPanel;
+
+    private GridLienzoPanel gridLienzoPanel;
+
+    @Before
+    public void setUp() {
+
+        gridLienzoPanel = spy(new GridLienzoPanel());
+
+        doReturn(mainPanel).when(gridLienzoPanel).getMainPanel();
+        doReturn(internalScrollPanel).when(gridLienzoPanel).getInternalScrollPanel();
+        doReturn(domElementContainer).when(gridLienzoPanel).getDomElementContainer();
+        doReturn(lienzoPanel).when(gridLienzoPanel).getLienzoPanel();
+        doReturn(gridLienzoScrollHandler).when(gridLienzoPanel).getGridLienzoScrollHandler();
+    }
+
+    @Test
+    public void testSetupMainPanel() {
+
+        gridLienzoPanel.setupMainPanel();
+
+        verify(domElementContainer).add(lienzoPanel);
+        verify(mainPanel).add(internalScrollPanel);
+        verify(mainPanel).add(domElementContainer);
+        verify(gridLienzoPanel).add(mainPanel);
+    }
+
+    @Test
+    public void testSetupScrollHandlers() {
+
+        final GridLienzoScrollHandler lienzoScrollHandler = mock(GridLienzoScrollHandler.class);
+
+        doReturn(lienzoScrollHandler).when(gridLienzoPanel).getGridLienzoScrollHandler();
+
+        gridLienzoPanel.setupScrollHandlers();
+
+        verify(lienzoScrollHandler).init();
+        verify(gridLienzoPanel).addMouseUpHandler();
+    }
+
+    @Test
+    public void testAddMouseUpHandler() {
+
+        final ArgumentCaptor<MouseUpHandler> handler = ArgumentCaptor.forClass(MouseUpHandler.class);
+        final MouseUpEvent mouseUpEvent = mock(MouseUpEvent.class);
+        final HandlerRegistration registration = mock(HandlerRegistration.class);
+
+        doReturn(registration).when(gridLienzoPanel).addMouseUpHandler(handler.capture());
+        doNothing().when(gridLienzoPanel).refreshScrollPosition();
+
+        gridLienzoPanel.addMouseUpHandler();
+
+        handler.getValue().onMouseUp(mouseUpEvent);
+
+        verify(gridLienzoPanel).refreshScrollPosition();
+    }
+
+    @Test
+    public void testOnResize() {
+
+        final ArgumentCaptor<Scheduler.ScheduledCommand> scheduledCommand = ArgumentCaptor.forClass(Scheduler.ScheduledCommand.class);
+
+        doNothing().when(gridLienzoPanel).updatePanelSize();
+        doNothing().when(gridLienzoPanel).refreshScrollPosition();
+        doNothing().when(gridLienzoPanel).scheduleDeferred(scheduledCommand.capture());
+
+        gridLienzoPanel.onResize();
+
+        scheduledCommand.getValue().execute();
+
+        verify(gridLienzoPanel).updatePanelSize();
+        verify(gridLienzoPanel).refreshScrollPosition();
+    }
+
+    @Test
+    public void testUpdatePanelSizeWhenWidthAndHeightAreGreaterThanZero() {
+
+        final Element element = mock(Element.class);
+        final Element parentElement = mock(Element.class);
+        final Integer scrollWidth = 14;
+        final Integer scrollHeight = 14;
+        final Integer width = 800;
+        final Integer height = 600;
+
+        doReturn(element).when(gridLienzoPanel).getElement();
+        doReturn(parentElement).when(element).getParentElement();
+        doReturn(width).when(parentElement).getOffsetWidth();
+        doReturn(height).when(parentElement).getOffsetHeight();
+        doReturn(scrollWidth).when(gridLienzoScrollHandler).scrollbarWidth();
+        doReturn(scrollHeight).when(gridLienzoScrollHandler).scrollbarHeight();
+
+        gridLienzoPanel.updatePanelSize();
+
+        verify(domElementContainer).setPixelSize(width - scrollWidth,
+                                                 height - scrollHeight);
+        verify(lienzoPanel).setPixelSize(width - scrollWidth,
+                                         height - scrollHeight);
+        verify(mainPanel).setPixelSize(width,
+                                       height);
+    }
+
+    @Test
+    public void testUpdatePanelSizeWhenWidthAndHeightAreNotGreaterThanZero() {
+
+        final Element element = mock(Element.class);
+        final Element parentElement = mock(Element.class);
+        final Integer width = 0;
+        final Integer height = 0;
+
+        doReturn(element).when(gridLienzoPanel).getElement();
+        doReturn(parentElement).when(element).getParentElement();
+        doReturn(width).when(parentElement).getOffsetWidth();
+        doReturn(height).when(parentElement).getOffsetHeight();
+
+        gridLienzoPanel.updatePanelSize();
+
+        verify(domElementContainer,
+               never()).setPixelSize(anyInt(),
+                                     anyInt());
+        verify(lienzoPanel,
+               never()).setPixelSize(anyInt(),
+                                     anyInt());
+        verify(mainPanel,
+               never()).setPixelSize(anyInt(),
+                                     anyInt());
+    }
+
+    @Test
+    public void testRefreshScrollPosition() {
+
+        final GridLienzoScrollHandler lienzoScrollHandler = mock(GridLienzoScrollHandler.class);
+
+        doReturn(lienzoScrollHandler).when(gridLienzoPanel).getGridLienzoScrollHandler();
+
+        gridLienzoPanel.refreshScrollPosition();
+
+        verify(lienzoScrollHandler).refreshScrollPosition();
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/RestrictedMousePanMediatorTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/pinning/impl/RestrictedMousePanMediatorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl;
+
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.Style;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.GridLayer;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class RestrictedMousePanMediatorTest {
+
+    private RestrictedMousePanMediator mediator;
+
+    @Before
+    public void setUp() {
+        mediator = spy(new RestrictedMousePanMediator());
+    }
+
+    @Test
+    public void testGetLayerViewport() {
+
+        final GridLayer layer = mock(GridLayer.class);
+        final Viewport expectedViewport = mock(Viewport.class);
+
+        doReturn(expectedViewport).when(layer).getViewport();
+        doReturn(layer).when(mediator).getGridLayer();
+
+        final Viewport actualViewport = mediator.getLayerViewport();
+
+        assertEquals(expectedViewport,
+                     actualViewport);
+    }
+
+    @Test
+    public void testSetCursor() {
+
+        final Viewport viewport = mock(Viewport.class);
+        final DivElement divElement = mock(DivElement.class);
+        final Style.Cursor cursor = mock(Style.Cursor.class);
+        final Style style = mock(Style.class);
+
+        doReturn(style).when(divElement).getStyle();
+        doReturn(divElement).when(viewport).getElement();
+        doReturn(viewport).when(mediator).getLayerViewport();
+
+        mediator.setCursor(cursor);
+
+        verify(style).setCursor(cursor);
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollBarsTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollBarsTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.scrollbars;
+
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.ui.AbsolutePanel;
+import com.google.gwt.user.client.ui.Panel;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class GridLienzoScrollBarsTest {
+
+    private static final Integer SCROLL_LEFT = 500;
+
+    private static final Integer SCROLL_TOP = 1500;
+
+    private static final Integer SCROLL_WIDTH = 4000;
+
+    private static final Integer SCROLL_HEIGHT = 4000;
+
+    private static final Integer CLIENT_WIDTH = 2500;
+
+    private static final Integer CLIENT_HEIGHT = 500;
+
+    @Mock
+    private GridLienzoScrollHandler gridLienzoScrollHandler;
+
+    private GridLienzoScrollBars gridLienzoScrollBars;
+
+    @Before
+    public void setUp() {
+        gridLienzoScrollBars = spy(new GridLienzoScrollBars(gridLienzoScrollHandler));
+    }
+
+    @Test
+    public void testGetHorizontalScrollPosition() {
+
+        doReturn(panel()).when(gridLienzoScrollHandler).getMainPanel();
+
+        final Double position = gridLienzoScrollBars.getHorizontalScrollPosition();
+
+        assertEquals(100d * SCROLL_LEFT / (SCROLL_WIDTH - CLIENT_WIDTH),
+                     position,
+                     0);
+    }
+
+    @Test
+    public void testGetHorizontalScrollPositionWhenScrollbarIsDisabled() {
+
+        doReturn(emptyPanel()).when(gridLienzoScrollHandler).getMainPanel();
+
+        final Double position = gridLienzoScrollBars.getHorizontalScrollPosition();
+
+        assertEquals(0,
+                     position,
+                     0);
+    }
+
+    @Test
+    public void testGetVerticalScrollPosition() {
+
+        doReturn(panel()).when(gridLienzoScrollHandler).getMainPanel();
+
+        final Double position = gridLienzoScrollBars.getVerticalScrollPosition();
+
+        assertEquals(100d * SCROLL_TOP / (SCROLL_HEIGHT - CLIENT_HEIGHT),
+                     position,
+                     0);
+    }
+
+    @Test
+    public void testGetVerticalScrollPositionWhenScrollbarIsDisabled() {
+
+        doReturn(emptyPanel()).when(gridLienzoScrollHandler).getMainPanel();
+
+        final Double position = gridLienzoScrollBars.getVerticalScrollPosition();
+
+        assertEquals(0,
+                     position,
+                     0);
+    }
+
+    @Test
+    public void testSetHorizontalScrollPosition() {
+
+        doReturn(panel()).when(gridLienzoScrollHandler).getMainPanel();
+
+        final Double percentage = 100d * SCROLL_LEFT / (SCROLL_WIDTH - CLIENT_WIDTH);
+
+        gridLienzoScrollBars.setHorizontalScrollPosition(percentage);
+
+        verify(gridLienzoScrollBars).setScrollLeft(eq(SCROLL_LEFT));
+    }
+
+    @Test
+    public void testSetVerticalScrollPosition() {
+
+        doReturn(panel()).when(gridLienzoScrollHandler).getMainPanel();
+
+        final Double percentage = 100d * SCROLL_TOP / (SCROLL_HEIGHT - CLIENT_HEIGHT);
+
+        gridLienzoScrollBars.setVerticalScrollPosition(percentage);
+
+        verify(gridLienzoScrollBars).setScrollTop(eq(SCROLL_TOP));
+    }
+
+    @Test
+    public void testPanel() {
+
+        final Panel expectedPanel = mock(AbsolutePanel.class);
+
+        doReturn(expectedPanel).when(gridLienzoScrollHandler).getMainPanel();
+
+        final Panel actualPanel = gridLienzoScrollBars.panel();
+
+        assertEquals(expectedPanel,
+                     actualPanel);
+    }
+
+    private Panel panel() {
+
+        final Panel panel = mock(AbsolutePanel.class);
+        final Element element = mock(Element.class);
+
+        doReturn(SCROLL_LEFT).when(element).getScrollLeft();
+        doReturn(SCROLL_TOP).when(element).getScrollTop();
+        doReturn(SCROLL_WIDTH).when(element).getScrollWidth();
+        doReturn(SCROLL_HEIGHT).when(element).getScrollHeight();
+        doReturn(CLIENT_WIDTH).when(element).getClientWidth();
+        doReturn(CLIENT_HEIGHT).when(element).getClientHeight();
+
+        doReturn(element).when(panel).getElement();
+
+        return panel;
+    }
+
+    private Panel emptyPanel() {
+
+        final Panel panel = mock(AbsolutePanel.class);
+        final Element element = mock(Element.class);
+
+        doReturn(0).when(element).getScrollLeft();
+        doReturn(0).when(element).getScrollTop();
+        doReturn(0).when(element).getScrollWidth();
+        doReturn(0).when(element).getScrollHeight();
+        doReturn(0).when(element).getClientWidth();
+        doReturn(0).when(element).getClientHeight();
+
+        doReturn(element).when(panel).getElement();
+
+        return panel;
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollBoundsTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollBoundsTest.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.scrollbars;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.Bounds;
+import org.uberfire.ext.wires.core.grids.client.model.impl.BaseBounds;
+import org.uberfire.ext.wires.core.grids.client.widget.grid.GridWidget;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class GridLienzoScrollBoundsTest {
+
+    @Mock
+    private DefaultGridLayer defaultGridLayer;
+
+    @Mock
+    private GridLienzoScrollHandler gridLienzoScrollHandler;
+
+    private GridLienzoScrollBounds gridLienzoScrollBounds;
+
+    @Before
+    public void setUp() {
+        gridLienzoScrollBounds = spy(new GridLienzoScrollBounds(gridLienzoScrollHandler));
+
+        doReturn(defaultGridLayer).when(gridLienzoScrollHandler).getDefaultGridLayer();
+    }
+
+    @Test
+    public void testMaxBoundXWhenAWidgetHasTheMaximumValue() {
+
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+
+        assertEquals(biggestWidget().getX() + biggestWidget().getWidth(),
+                     gridLienzoScrollBounds.maxBoundX(),
+                     0);
+    }
+
+    @Test
+    public void testMaxBoundXWhenVisibleBoundsHasTheMaximumValue() {
+
+        final BaseBounds visibleBounds = makeMaxBounds();
+
+        doReturn(true).when(gridLienzoScrollBounds).hasVisibleBounds();
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+        doReturn(visibleBounds).when(defaultGridLayer).getVisibleBounds();
+
+        assertEquals(visibleBounds.getWidth(),
+                     gridLienzoScrollBounds.maxBoundX(),
+                     0);
+    }
+
+    @Test
+    public void testMaxBoundXWhenDefaultBoundsHasTheMaximumValue() {
+
+        final BaseBounds defaultBounds = makeMaxBounds();
+
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+        doReturn(defaultBounds).when(gridLienzoScrollBounds).getDefaultBounds();
+
+        assertEquals(defaultBounds.getWidth(),
+                     gridLienzoScrollBounds.maxBoundX(),
+                     0);
+    }
+
+    @Test
+    public void testMaxBoundYWhenAWidgetHasTheMaximumValue() {
+
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+
+        assertEquals(biggestWidget().getY() + biggestWidget().getHeight(),
+                     gridLienzoScrollBounds.maxBoundY(),
+                     0);
+    }
+
+    @Test
+    public void testMaxBoundYWhenVisibleBoundsHasTheMaximumValue() {
+
+        final BaseBounds visibleBounds = makeMaxBounds();
+
+        doReturn(true).when(gridLienzoScrollBounds).hasVisibleBounds();
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+        doReturn(visibleBounds).when(defaultGridLayer).getVisibleBounds();
+
+        assertEquals(visibleBounds.getHeight(),
+                     gridLienzoScrollBounds.maxBoundY(),
+                     0);
+    }
+
+    @Test
+    public void testMaxBoundYWhenDefaultBoundsHasTheMaximumValue() {
+
+        final BaseBounds defaultBounds = makeMaxBounds();
+
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+        doReturn(defaultBounds).when(gridLienzoScrollBounds).getDefaultBounds();
+
+        assertEquals(defaultBounds.getHeight(),
+                     gridLienzoScrollBounds.maxBoundY(),
+                     0);
+    }
+
+    @Test
+    public void testMinBoundXWhenAWidgetHasTheMinimumValue() {
+
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+
+        assertEquals(biggestWidget().getX(),
+                     gridLienzoScrollBounds.minBoundX(),
+                     0);
+    }
+
+    @Test
+    public void testMinBoundXWhenVisibleBoundsHasTheMinimumValue() {
+
+        final BaseBounds visibleBounds = makeMinBounds();
+
+        doReturn(true).when(gridLienzoScrollBounds).hasVisibleBounds();
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+        doReturn(visibleBounds).when(defaultGridLayer).getVisibleBounds();
+
+        assertEquals(visibleBounds.getX(),
+                     gridLienzoScrollBounds.minBoundX(),
+                     0);
+    }
+
+    @Test
+    public void testMinBoundXWhenDefaultBoundsHasTheMinimumValue() {
+
+        final BaseBounds defaultBounds = makeMinBounds();
+
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+        doReturn(defaultBounds).when(gridLienzoScrollBounds).getDefaultBounds();
+
+        assertEquals(defaultBounds.getX(),
+                     gridLienzoScrollBounds.minBoundX(),
+                     0);
+    }
+
+    @Test
+    public void testMinBoundYWhenAWidgetHasTheMinimumValue() {
+
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+
+        assertEquals(biggestWidget().getY(),
+                     gridLienzoScrollBounds.minBoundY(),
+                     0);
+    }
+
+    @Test
+    public void testMinBoundYWhenVisibleBoundsHasTheMinimumValue() {
+
+        final BaseBounds visibleBounds = makeMinBounds();
+
+        doReturn(true).when(gridLienzoScrollBounds).hasVisibleBounds();
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+        doReturn(visibleBounds).when(defaultGridLayer).getVisibleBounds();
+
+        assertEquals(visibleBounds.getY(),
+                     gridLienzoScrollBounds.minBoundY(),
+                     0);
+    }
+
+    @Test
+    public void testMinBoundYWhenDefaultBoundsHasTheMinimumValue() {
+
+        final BaseBounds defaultBounds = makeMinBounds();
+
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+        doReturn(defaultBounds).when(gridLienzoScrollBounds).getDefaultBounds();
+
+        assertEquals(defaultBounds.getY(),
+                     gridLienzoScrollBounds.minBoundY(),
+                     0);
+    }
+
+    @Test
+    public void testSetDefaultBounds() {
+
+        final Bounds bounds = mock(Bounds.class);
+
+        gridLienzoScrollBounds.setDefaultBounds(bounds);
+
+        assertEquals(bounds,
+                     gridLienzoScrollBounds.getDefaultBounds());
+    }
+
+    @Test
+    public void testGetVisibleBounds() {
+
+        final DefaultGridLayer defaultGridLayer = mock(DefaultGridLayer.class);
+        final Bounds expectedBounds = mock(Bounds.class);
+
+        doReturn(expectedBounds).when(defaultGridLayer).getVisibleBounds();
+        doReturn(defaultGridLayer).when(gridLienzoScrollBounds).getDefaultGridLayer();
+
+        final Bounds actualBounds = gridLienzoScrollBounds.getVisibleBounds();
+
+        assertEquals(expectedBounds,
+                     actualBounds);
+    }
+
+    @Test
+    public void testGetGridWidgets() {
+
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+
+        final Set<GridWidget> gridWidgets = gridLienzoScrollBounds.getGridWidgets();
+
+        assertEquals(4,
+                     gridWidgets.size());
+    }
+
+    @Test
+    public void testGetVisibleGridWidgets() {
+
+        doReturn(getGridWidgets()).when(defaultGridLayer).getGridWidgets();
+
+        final Stream<GridWidget> gridWidgets = gridLienzoScrollBounds.getVisibleGridWidgets();
+
+        assertEquals(3,
+                     gridWidgets.count());
+    }
+
+    @Test
+    public void testHasDefaultBoundsWhenDefaultBoundsIsNull() {
+
+        doReturn(null).when(gridLienzoScrollBounds).getDefaultBounds();
+
+        assertFalse(gridLienzoScrollBounds.hasDefaultBounds());
+    }
+
+    @Test
+    public void testHasDefaultBoundsWhenDefaultBoundsIsNotNull() {
+
+        doReturn(mock(Bounds.class)).when(gridLienzoScrollBounds).getDefaultBounds();
+
+        assertTrue(gridLienzoScrollBounds.hasDefaultBounds());
+    }
+
+    @Test
+    public void testHasVisibleBoundsWhenViewportIsNull() {
+
+        doReturn(null).when(gridLienzoScrollHandler).getViewport();
+
+        assertFalse(gridLienzoScrollBounds.hasVisibleBounds());
+    }
+
+    @Test
+    public void testHasVisibleBoundsWhenViewportIsNotNull() {
+
+        doReturn(mock(Viewport.class)).when(defaultGridLayer).getViewport();
+        doReturn(defaultGridLayer).when(gridLienzoScrollBounds).getDefaultGridLayer();
+
+        assertTrue(gridLienzoScrollBounds.hasVisibleBounds());
+    }
+
+    private GridWidget makeGridWidget(final Double x,
+                                      final Double y,
+                                      final Double width,
+                                      final Double height,
+                                      final boolean visible) {
+
+        final GridWidget mock = mock(GridWidget.class);
+
+        when(mock.getX()).thenReturn(x);
+        when(mock.getY()).thenReturn(y);
+        when(mock.getWidth()).thenReturn(width);
+        when(mock.getHeight()).thenReturn(height);
+        when(mock.isVisible()).thenReturn(visible);
+
+        return mock;
+    }
+
+    private HashSet<GridWidget> getGridWidgets() {
+        return new HashSet<GridWidget>() {{
+            add(smallestWidget());
+            add(mediumWidget());
+            add(biggestWidget());
+            add(hiddenWidget());
+        }};
+    }
+
+    private BaseBounds makeMaxBounds() {
+        return new BaseBounds(0,
+                              0,
+                              8000d,
+                              6000d);
+    }
+
+    private BaseBounds makeMinBounds() {
+        return new BaseBounds(-8000d,
+                              -6000d,
+                              1d,
+                              1d);
+    }
+
+    private GridWidget biggestWidget() {
+        return makeGridWidget(-3840d,
+                              -2160d,
+                              3840d * 2,
+                              2160d * 2,
+                              true);
+    }
+
+    private GridWidget mediumWidget() {
+        return makeGridWidget(-2560d,
+                              -1440d,
+                              2560d * 2,
+                              1440d * 2,
+                              true);
+    }
+
+    private GridWidget smallestWidget() {
+        return makeGridWidget(-1920d,
+                              -1080d,
+                              1920d * 2,
+                              1080d * 2,
+                              true);
+    }
+
+    private GridWidget hiddenWidget() {
+        return makeGridWidget(-3840d,
+                              -2160d,
+                              3840d * 2,
+                              2160d * 2,
+                              false);
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollHandlerTest.java
@@ -1,0 +1,595 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.scrollbars;
+
+import com.ait.lienzo.client.core.event.NodeMouseDownEvent;
+import com.ait.lienzo.client.core.event.NodeMouseMoveEvent;
+import com.ait.lienzo.client.core.mediator.Mediators;
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.client.core.types.Transform;
+import com.ait.lienzo.client.widget.LienzoPanel;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.event.dom.client.ScrollEvent;
+import com.google.gwt.event.dom.client.ScrollHandler;
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.ui.AbsolutePanel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLienzoPanel;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.pinning.impl.RestrictedMousePanMediator;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.uberfire.ext.wires.core.grids.client.widget.scrollbars.GridLienzoScrollHandler.DEFAULT_INTERNAL_SCROLL_HEIGHT;
+import static org.uberfire.ext.wires.core.grids.client.widget.scrollbars.GridLienzoScrollHandler.DEFAULT_INTERNAL_SCROLL_WIDTH;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class GridLienzoScrollHandlerTest {
+
+    @Mock
+    private GridLienzoPanel gridLienzoPanel;
+
+    @Mock
+    private GridLienzoScrollPosition scrollPosition;
+
+    @Mock
+    private GridLienzoScrollBounds scrollBounds;
+
+    @Mock
+    private DefaultGridLayer defaultGridLayer;
+
+    @Mock
+    private Viewport viewport;
+
+    @Mock
+    private Transform transform;
+
+    private GridLienzoScrollHandler gridLienzoScrollHandler;
+
+    @Before
+    public void setUp() {
+        this.gridLienzoScrollHandler = spy(new GridLienzoScrollHandler(gridLienzoPanel));
+
+        doReturn(transform).when(viewport).getTransform();
+        doReturn(viewport).when(defaultGridLayer).getViewport();
+        doReturn(scrollBounds).when(gridLienzoScrollHandler).scrollBounds();
+        doReturn(scrollPosition).when(gridLienzoScrollHandler).scrollPosition();
+        doReturn(defaultGridLayer).when(gridLienzoScrollHandler).getDefaultGridLayer();
+    }
+
+    @Test
+    public void testInit() {
+        doNothing().when(gridLienzoScrollHandler).setupGridLienzoScrollStyle();
+        doNothing().when(gridLienzoScrollHandler).setupScrollBarSynchronization();
+        doNothing().when(gridLienzoScrollHandler).setupMouseDragSynchronization();
+
+        gridLienzoScrollHandler.init();
+
+        verify(gridLienzoScrollHandler).setupGridLienzoScrollStyle();
+        verify(gridLienzoScrollHandler).setupScrollBarSynchronization();
+        verify(gridLienzoScrollHandler).setupMouseDragSynchronization();
+    }
+
+    @Test
+    public void testSetupGridLienzoScrollStyle() {
+        final GridLienzoScrollUI scrollUI = mock(GridLienzoScrollUI.class);
+
+        doReturn(scrollUI).when(gridLienzoScrollHandler).gridLienzoScrollUI();
+
+        gridLienzoScrollHandler.setupGridLienzoScrollStyle();
+
+        verify(scrollUI).setup();
+    }
+
+    @Test
+    public void testGridLienzoScrollUI() {
+        final GridLienzoScrollUI scrollUI = gridLienzoScrollHandler.gridLienzoScrollUI();
+
+        assertTrue(scrollUI != null);
+    }
+
+    @Test
+    public void testSetupScrollBarSynchronization() {
+
+        final AbsolutePanel mainPanel = mock(AbsolutePanel.class);
+        final ScrollHandler scrollHandler = mock(ScrollHandler.class);
+
+        doReturn(scrollHandler).when(gridLienzoScrollHandler).onScroll();
+        doReturn(mainPanel).when(gridLienzoScrollHandler).getMainPanel();
+        doNothing().when(gridLienzoScrollHandler).synchronizeScrollSize();
+
+        gridLienzoScrollHandler.setupScrollBarSynchronization();
+
+        verify(gridLienzoScrollHandler).synchronizeScrollSize();
+        verify(mainPanel).addDomHandler(scrollHandler,
+                                        ScrollEvent.getType());
+    }
+
+    @Test
+    public void testSynchronizeScrollSize() {
+
+        final AbsolutePanel panel = mock(AbsolutePanel.class);
+        final Integer internalScrollPanelWidth = 42;
+        final Integer internalScrollPanelHeight = 58;
+
+        doReturn(internalScrollPanelWidth).when(gridLienzoScrollHandler).calculateInternalScrollPanelWidth();
+        doReturn(internalScrollPanelHeight).when(gridLienzoScrollHandler).calculateInternalScrollPanelHeight();
+        doReturn(panel).when(gridLienzoScrollHandler).getInternalScrollPanel();
+
+        gridLienzoScrollHandler.synchronizeScrollSize();
+
+        verify(panel).setPixelSize(eq(internalScrollPanelWidth),
+                                   eq(internalScrollPanelHeight));
+    }
+
+    @Test
+    public void testCalculateInternalScrollPanelWidthWhenScrollbarXIsEnabled() {
+
+        final Double maximumBoundX = +20d;
+        final Double minimumBoundX = -20d;
+        final Double zoomLevel = 0.75d;
+        final Double currentScrollPosition = 10d;
+
+        doReturn(maximumBoundX).when(scrollBounds).maxBoundX();
+        doReturn(minimumBoundX).when(scrollBounds).minBoundX();
+        doReturn(zoomLevel).when(transform).getScaleX();
+        doReturn(currentScrollPosition).when(scrollPosition).deltaX();
+
+        final Integer panelWidth = gridLienzoScrollHandler.calculateInternalScrollPanelWidth();
+        final Integer scaledWidth = (int) ((maximumBoundX - minimumBoundX) * zoomLevel);
+
+        assertEquals(scaledWidth,
+                     panelWidth,
+                     0);
+    }
+
+    @Test
+    public void testCalculateInternalScrollPanelWidthWhenScrollbarXIsDisabled() {
+
+        final Double maximumBoundX = +20d;
+        final Double minimumBoundX = -20d;
+        final Double zoomLevel = 0.75d;
+        final Double currentScrollPosition = 0d;
+
+        doReturn(maximumBoundX).when(scrollBounds).maxBoundX();
+        doReturn(minimumBoundX).when(scrollBounds).minBoundX();
+        doReturn(zoomLevel).when(transform).getScaleX();
+        doReturn(currentScrollPosition).when(scrollPosition).deltaX();
+
+        final Integer panelWidth = gridLienzoScrollHandler.calculateInternalScrollPanelWidth();
+
+        assertEquals(DEFAULT_INTERNAL_SCROLL_WIDTH,
+                     panelWidth,
+                     0);
+    }
+
+    @Test
+    public void testCalculateInternalScrollPanelHeightWhenScrollbarYIsEnabled() {
+
+        final Double maximumBoundY = +20d;
+        final Double minimumBoundY = -20d;
+        final Double zoomLevel = 0.75d;
+        final Double currentScrollPosition = 10d;
+
+        doReturn(maximumBoundY).when(scrollBounds).maxBoundY();
+        doReturn(minimumBoundY).when(scrollBounds).minBoundY();
+        doReturn(zoomLevel).when(transform).getScaleY();
+        doReturn(currentScrollPosition).when(scrollPosition).deltaY();
+
+        final Integer panelHeight = gridLienzoScrollHandler.calculateInternalScrollPanelHeight();
+        final Integer scaledHeight = (int) ((maximumBoundY - minimumBoundY) * zoomLevel);
+
+        assertEquals(scaledHeight,
+                     panelHeight,
+                     0);
+    }
+
+    @Test
+    public void testCalculateInternalScrollPanelHeightWhenScrollbarYIsDisabled() {
+
+        final Double maximumBoundY = +20d;
+        final Double minimumBoundY = -20d;
+        final Double zoomLevel = 0.75d;
+        final Double currentScrollPosition = 0d;
+
+        doReturn(maximumBoundY).when(scrollBounds).maxBoundY();
+        doReturn(minimumBoundY).when(scrollBounds).minBoundY();
+        doReturn(zoomLevel).when(transform).getScaleY();
+        doReturn(currentScrollPosition).when(scrollPosition).deltaY();
+
+        final Integer panelHeight = gridLienzoScrollHandler.calculateInternalScrollPanelHeight();
+
+        assertEquals(DEFAULT_INTERNAL_SCROLL_HEIGHT,
+                     panelHeight,
+                     0);
+    }
+
+    @Test
+    public void testSetupMouseDragSynchronization() {
+
+        final RestrictedMousePanMediator mediator = mock(RestrictedMousePanMediator.class);
+        final LienzoPanel lienzoPanel = mock(LienzoPanel.class);
+        final Viewport viewport = mock(Viewport.class);
+        final Mediators mediators = mock(Mediators.class);
+
+        doReturn(mediator).when(gridLienzoScrollHandler).makeRestrictedMousePanMediator();
+        doReturn(lienzoPanel).when(gridLienzoScrollHandler).getLienzoPanel();
+        doReturn(viewport).when(lienzoPanel).getViewport();
+        doReturn(mediators).when(viewport).getMediators();
+
+        gridLienzoScrollHandler.setupMouseDragSynchronization();
+
+        verify(mediators).push(mediator);
+    }
+
+    @Test
+    public void testOnScrollWhenMouseIsNotDragging() {
+
+        final RestrictedMousePanMediator mediator = mock(RestrictedMousePanMediator.class);
+        final ScrollEvent scrollEvent = mock(ScrollEvent.class);
+
+        doReturn(false).when(mediator).isDragging();
+        doReturn(mediator).when(gridLienzoScrollHandler).getMousePanMediator();
+        doNothing().when(gridLienzoScrollHandler).updateGridLienzoPosition();
+
+        final ScrollHandler scrollHandler = gridLienzoScrollHandler.onScroll();
+        scrollHandler.onScroll(scrollEvent);
+
+        verify(gridLienzoScrollHandler).updateGridLienzoPosition();
+    }
+
+    @Test
+    public void testOnScrollWhenMouseIsDragging() {
+
+        final RestrictedMousePanMediator mediator = mock(RestrictedMousePanMediator.class);
+        final ScrollEvent scrollEvent = mock(ScrollEvent.class);
+
+        doReturn(true).when(mediator).isDragging();
+        doReturn(mediator).when(gridLienzoScrollHandler).getMousePanMediator();
+
+        final ScrollHandler scrollHandler = gridLienzoScrollHandler.onScroll();
+        scrollHandler.onScroll(scrollEvent);
+
+        verify(gridLienzoScrollHandler,
+               never()).updateGridLienzoPosition();
+    }
+
+    @Test
+    public void testRefreshScrollPosition() {
+
+        final GridLienzoScrollPosition scrollPosition = mock(GridLienzoScrollPosition.class);
+        final Double internalScrollPanelWidth = 42d;
+        final Double internalScrollPanelHeight = 58d;
+
+        doReturn(internalScrollPanelWidth).when(scrollPosition).currentRelativeX();
+        doReturn(internalScrollPanelHeight).when(scrollPosition).currentRelativeY();
+        doReturn(scrollPosition).when(gridLienzoScrollHandler).scrollPosition();
+        doNothing().when(gridLienzoScrollHandler).synchronizeScrollSize();
+        doNothing().when(gridLienzoScrollHandler).setScrollBarsPosition(anyDouble(),
+                                                                        anyDouble());
+
+        gridLienzoScrollHandler.refreshScrollPosition();
+
+        verify(gridLienzoScrollHandler).synchronizeScrollSize();
+        verify(gridLienzoScrollHandler).setScrollBarsPosition(internalScrollPanelWidth,
+                                                              internalScrollPanelHeight);
+    }
+
+    @Test
+    public void testUpdateGridLienzoPosition() {
+
+        final GridLienzoScrollBars scrollBars = mock(GridLienzoScrollBars.class);
+        final GridLienzoScrollPosition scrollPosition = mock(GridLienzoScrollPosition.class);
+        final Double percentageX = 40d;
+        final Double percentageY = 60d;
+        final Double currentXPosition = 400d;
+        final Double currentYPosition = 600d;
+
+        doReturn(scrollBars).when(gridLienzoScrollHandler).scrollBars();
+        doReturn(scrollPosition).when(gridLienzoScrollHandler).scrollPosition();
+        doReturn(percentageX).when(scrollBars).getHorizontalScrollPosition();
+        doReturn(percentageY).when(scrollBars).getVerticalScrollPosition();
+        doReturn(currentXPosition).when(scrollPosition).currentPositionX(percentageX);
+        doReturn(currentYPosition).when(scrollPosition).currentPositionY(percentageY);
+        doNothing().when(gridLienzoScrollHandler).updateGridLienzoTransform(anyDouble(),
+                                                                            anyDouble());
+
+        gridLienzoScrollHandler.updateGridLienzoPosition();
+
+        verify(gridLienzoScrollHandler).updateGridLienzoTransform(currentXPosition,
+                                                                  currentYPosition);
+    }
+
+    @Test
+    public void testUpdateGridLienzoPositionWithPositions() {
+
+        final DefaultGridLayer defaultGridLayer = mock(DefaultGridLayer.class);
+        final Viewport viewport = mock(Viewport.class);
+        final Transform transform = mock(Transform.class);
+        final Transform copy = mock(Transform.class);
+        final Transform translate = mock(Transform.class);
+        final Double oldTranslateX = 200d;
+        final Double oldTranslateY = 200d;
+        final Double scaleX = 2d;
+        final Double scaleY = 2d;
+        final Double currentXPosition = 500d;
+        final Double currentYPosition = 500d;
+
+        doReturn(defaultGridLayer).when(gridLienzoScrollHandler).getDefaultGridLayer();
+        doReturn(viewport).when(defaultGridLayer).getViewport();
+        doReturn(transform).when(viewport).getTransform();
+        doReturn(oldTranslateX).when(transform).getTranslateX();
+        doReturn(oldTranslateY).when(transform).getTranslateY();
+        doReturn(scaleX).when(transform).getScaleX();
+        doReturn(scaleY).when(transform).getScaleY();
+        doReturn(copy).when(transform).copy();
+        doReturn(translate).when(copy).translate(anyDouble(),
+                                                 anyDouble());
+
+        gridLienzoScrollHandler.updateGridLienzoTransform(currentXPosition,
+                                                          currentYPosition);
+
+        final Double deltaX = currentXPosition - (oldTranslateX / scaleX);
+        final Double deltaY = currentYPosition - (oldTranslateY / scaleY);
+
+        verify(defaultGridLayer).batch();
+        verify(viewport).setTransform(translate);
+        verify(copy).translate(deltaX,
+                               deltaY);
+    }
+
+    @Test
+    public void testSetScrollBarsPosition() {
+
+        final GridLienzoScrollBars scrollBars = mock(GridLienzoScrollBars.class);
+        final Double xPercentage = 42d;
+        final Double yPercentage = 58d;
+
+        doReturn(scrollBars).when(gridLienzoScrollHandler).scrollBars();
+
+        gridLienzoScrollHandler.setScrollBarsPosition(xPercentage,
+                                                      yPercentage);
+
+        verify(scrollBars).setHorizontalScrollPosition(xPercentage);
+        verify(scrollBars).setVerticalScrollPosition(yPercentage);
+    }
+
+    @Test
+    public void testMakeRestrictedMousePanMediator() {
+
+        final Viewport viewport = viewportMock();
+        final DefaultGridLayer defaultGridLayer = mock(DefaultGridLayer.class);
+        final RestrictedMousePanMediator restrictedMousePanMediator = spy(gridLienzoScrollHandler.makeRestrictedMousePanMediator());
+
+        doNothing().when(gridLienzoScrollHandler).refreshScrollPosition();
+        doReturn(viewport).when(restrictedMousePanMediator).getViewport();
+        doReturn(defaultGridLayer).when(gridLienzoScrollHandler).getDefaultGridLayer();
+        doReturn(viewport).when(defaultGridLayer).getViewport();
+
+        restrictedMousePanMediator.handleEvent(mouseDownEventMock());
+        restrictedMousePanMediator.handleEvent(mouseMoveEventMock());
+
+        verify(gridLienzoScrollHandler).refreshScrollPosition();
+    }
+
+    @Test
+    public void testGetMousePanMediator() {
+
+        final RestrictedMousePanMediator expectedMediator = mock(RestrictedMousePanMediator.class);
+        final LienzoPanel lienzoPanel = mock(LienzoPanel.class);
+        final Viewport viewport = mock(Viewport.class);
+        final Mediators mediators = mock(Mediators.class);
+
+        doReturn(lienzoPanel).when(gridLienzoScrollHandler).getLienzoPanel();
+        doReturn(viewport).when(lienzoPanel).getViewport();
+        doReturn(mediators).when(viewport).getMediators();
+        doReturn(expectedMediator).when(gridLienzoScrollHandler).makeRestrictedMousePanMediator();
+
+        gridLienzoScrollHandler.setupMouseDragSynchronization();
+
+        final RestrictedMousePanMediator actualMediator = gridLienzoScrollHandler.getMousePanMediator();
+
+        assertEquals(expectedMediator,
+                     actualMediator);
+    }
+
+    @Test
+    public void testGetMainPanel() {
+
+        final AbsolutePanel expectedPanel = mock(AbsolutePanel.class);
+
+        doReturn(expectedPanel).when(gridLienzoPanel).getMainPanel();
+
+        final AbsolutePanel actualPanel = gridLienzoScrollHandler.getMainPanel();
+
+        assertEquals(expectedPanel,
+                     actualPanel);
+    }
+
+    @Test
+    public void testGetInternalScrollPanel() {
+
+        final AbsolutePanel expectedPanel = mock(AbsolutePanel.class);
+
+        doReturn(expectedPanel).when(gridLienzoPanel).getInternalScrollPanel();
+
+        final AbsolutePanel actualPanel = gridLienzoScrollHandler.getInternalScrollPanel();
+
+        assertEquals(expectedPanel,
+                     actualPanel);
+    }
+
+    @Test
+    public void testGetDomElementContainer() {
+
+        final AbsolutePanel expectedPanel = mock(AbsolutePanel.class);
+
+        doReturn(expectedPanel).when(gridLienzoPanel).getDomElementContainer();
+
+        final AbsolutePanel actualPanel = gridLienzoScrollHandler.getDomElementContainer();
+
+        assertEquals(expectedPanel,
+                     actualPanel);
+    }
+
+    @Test
+    public void testGetLienzoPanel() {
+
+        final LienzoPanel expectedPanel = mock(LienzoPanel.class);
+
+        doReturn(expectedPanel).when(gridLienzoPanel).getLienzoPanel();
+
+        final LienzoPanel actualPanel = gridLienzoScrollHandler.getLienzoPanel();
+
+        assertEquals(expectedPanel,
+                     actualPanel);
+    }
+
+    @Test
+    public void testGetDefaultGridLayerWhenLienzoGridLayerIsNotNull() {
+
+        final DefaultGridLayer expectedLayer = mock(DefaultGridLayer.class);
+
+        doReturn(expectedLayer).when(gridLienzoPanel).getDefaultGridLayer();
+        doCallRealMethod().when(gridLienzoScrollHandler).getDefaultGridLayer();
+
+        final DefaultGridLayer actualLayer = gridLienzoScrollHandler.getDefaultGridLayer();
+
+        assertEquals(expectedLayer,
+                     actualLayer);
+    }
+
+    @Test
+    public void testGetDefaultGridLayerWhenLienzoGridLayerIsNull() {
+
+        final DefaultGridLayer expectedLayer = mock(DefaultGridLayer.class);
+
+        doReturn(null).when(gridLienzoPanel).getDefaultGridLayer();
+        doReturn(expectedLayer).when(gridLienzoScrollHandler).emptyLayer();
+        doCallRealMethod().when(gridLienzoScrollHandler).getDefaultGridLayer();
+
+        final DefaultGridLayer actualLayer = gridLienzoScrollHandler.getDefaultGridLayer();
+
+        assertEquals(expectedLayer,
+                     actualLayer);
+    }
+
+    @Test
+    public void testEmptyLayer() {
+        assertTrue(gridLienzoScrollHandler.emptyLayer() != null);
+    }
+
+    @Test
+    public void testScrollBars() {
+        assertTrue(gridLienzoScrollHandler.scrollBars() != null);
+    }
+
+    @Test
+    public void testScrollPosition() {
+        assertTrue(gridLienzoScrollHandler.scrollPosition() != null);
+    }
+
+    @Test
+    public void testScrollBounds() {
+        assertTrue(gridLienzoScrollHandler.scrollBounds() != null);
+    }
+
+    @Test
+    public void testScrollbarWidth() {
+
+        final AbsolutePanel mainPanel = mock(AbsolutePanel.class);
+        final Element element = mock(Element.class);
+        final Integer offsetWidth = 1014;
+        final Integer clientWidth = 1000;
+
+        doReturn(offsetWidth).when(element).getOffsetWidth();
+        doReturn(clientWidth).when(element).getClientWidth();
+        doReturn(element).when(mainPanel).getElement();
+        doReturn(mainPanel).when(gridLienzoScrollHandler).getMainPanel();
+
+        final Integer expectedScrollbarWidth = offsetWidth - clientWidth;
+        final Integer actualScrollbarWidth = gridLienzoScrollHandler.scrollbarWidth();
+
+        assertEquals(expectedScrollbarWidth,
+                     actualScrollbarWidth);
+    }
+
+    @Test
+    public void testScrollbarHeight() {
+
+        final AbsolutePanel mainPanel = mock(AbsolutePanel.class);
+        final Element element = mock(Element.class);
+        final Integer offsetHeight = 1014;
+        final Integer clientHeight = 1000;
+
+        doReturn(offsetHeight).when(element).getOffsetHeight();
+        doReturn(clientHeight).when(element).getClientHeight();
+        doReturn(element).when(mainPanel).getElement();
+        doReturn(mainPanel).when(gridLienzoScrollHandler).getMainPanel();
+
+        final Integer expectedScrollbarHeight = offsetHeight - clientHeight;
+        final Integer actualScrollbarHeight = gridLienzoScrollHandler.scrollbarHeight();
+
+        assertEquals(expectedScrollbarHeight,
+                     actualScrollbarHeight);
+    }
+
+    private Viewport viewportMock() {
+
+        final Viewport viewport = mock(Viewport.class);
+        final DivElement divElement = mock(DivElement.class);
+        final Style style = mock(Style.class);
+
+        doReturn(style).when(divElement).getStyle();
+        doReturn(divElement).when(viewport).getElement();
+        doReturn(transformMock()).when(viewport).getTransform();
+
+        return viewport;
+    }
+
+    public Transform transformMock() {
+
+        final Transform transform = mock(Transform.class);
+
+        doReturn(transform).when(transform).getInverse();
+
+        return transform;
+    }
+
+    private NodeMouseDownEvent mouseDownEventMock() {
+
+        final NodeMouseDownEvent mouseDownEvent = mock(NodeMouseDownEvent.class);
+
+        doReturn(NodeMouseDownEvent.getType()).when(mouseDownEvent).getAssociatedType();
+
+        return mouseDownEvent;
+    }
+
+    private NodeMouseMoveEvent mouseMoveEventMock() {
+
+        final NodeMouseMoveEvent mouseMoveEvent = mock(NodeMouseMoveEvent.class);
+
+        doReturn(NodeMouseMoveEvent.getType()).when(mouseMoveEvent).getAssociatedType();
+
+        return mouseMoveEvent;
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollPositionTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollPositionTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.scrollbars;
+
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.client.core.types.Transform;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.ext.wires.core.grids.client.model.Bounds;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.DefaultGridLayer;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class GridLienzoScrollPositionTest {
+
+    private static final Double MAX_BOUND_X = 2000d;
+
+    private static final Double MAX_BOUND_Y = 2000d;
+
+    private static final Double MIN_BOUND_X = -2000d;
+
+    private static final Double MIN_BOUND_Y = -2000d;
+
+    private static final Double VISIBLE_BOUND_WIDTH = 2500d;
+
+    private static final Double VISIBLE_BOUND_HEIGHT = 500d;
+
+    private static final Double TRANSLATE_X = 1300d;
+
+    private static final Double TRANSLATE_Y = 700d;
+
+    private static final Double SCALE_X = 1d;
+
+    private static final Double SCALE_Y = 1d;
+
+    private static final Double CURRENT_Y = -(TRANSLATE_Y / SCALE_Y + MIN_BOUND_Y);
+
+    private static final Double CURRENT_X = -(TRANSLATE_X / SCALE_X + MIN_BOUND_X);
+
+    private static final Double DELTA_Y = MAX_BOUND_Y - MIN_BOUND_Y - VISIBLE_BOUND_HEIGHT;
+
+    private static final Double DELTA_X = MAX_BOUND_X - MIN_BOUND_X - VISIBLE_BOUND_WIDTH;
+
+    @Mock
+    private GridLienzoScrollHandler gridLienzoScrollHandler;
+
+    @Mock
+    private DefaultGridLayer defaultGridLayer;
+
+    @Mock
+    private GridLienzoScrollBounds scrollBounds;
+
+    private GridLienzoScrollPosition gridLienzoScrollPosition;
+
+    @Before
+    public void setUp() {
+
+        gridLienzoScrollPosition = spy(new GridLienzoScrollPosition(gridLienzoScrollHandler));
+
+        doReturn(makeTransform()).when(gridLienzoScrollPosition).getTransform();
+        doReturn(makeVisibleBounds()).when(gridLienzoScrollPosition).getVisibleBounds();
+        doReturn(makeScrollBoundsHelper()).when(gridLienzoScrollPosition).bounds();
+        doReturn(defaultGridLayer).when(gridLienzoScrollHandler).getDefaultGridLayer();
+        doReturn(scrollBounds).when(gridLienzoScrollHandler).scrollBounds();
+    }
+
+    @Test
+    public void testGetCurrentXLevel() {
+
+        final Double actualLevel = gridLienzoScrollPosition.currentRelativeX();
+        final Double expectedLevel = 100 * CURRENT_X / DELTA_X;
+
+        assertEquals(expectedLevel,
+                     actualLevel,
+                     0);
+    }
+
+    @Test
+    public void testGetCurrentXLevelWhenDeltaXIsZero() {
+
+        doReturn(0d).when(gridLienzoScrollPosition).deltaX();
+
+        final Double actualLevel = gridLienzoScrollPosition.currentRelativeX();
+        final Double expectedLevel = 0d;
+
+        assertEquals(expectedLevel,
+                     actualLevel,
+                     0);
+    }
+
+    @Test
+    public void testGetCurrentYLevel() {
+
+        final Double actualLevel = gridLienzoScrollPosition.currentRelativeY();
+        final Double expectedLevel = 100 * CURRENT_Y / DELTA_Y;
+
+        assertEquals(actualLevel,
+                     expectedLevel,
+                     0);
+    }
+
+    @Test
+    public void testGetCurrentYLevelWhenDeltaYIsZero() {
+
+        doReturn(0d).when(gridLienzoScrollPosition).deltaY();
+
+        final Double actualLevel = gridLienzoScrollPosition.currentRelativeY();
+        final Double expectedLevel = 0d;
+
+        assertEquals(expectedLevel,
+                     actualLevel,
+                     0);
+    }
+
+    @Test
+    public void testCurrentXPosition() {
+
+        final Double level = 46.66d;
+        final Double expectedPosition = -(MIN_BOUND_X + (DELTA_X * level / 100));
+        final Double actualPosition = gridLienzoScrollPosition.currentPositionX(level);
+
+        assertEquals(expectedPosition,
+                     actualPosition,
+                     0);
+    }
+
+    @Test
+    public void testCurrentYPosition() {
+
+        final Double level = 37.14d;
+        final Double expectedPosition = -(MIN_BOUND_Y + (DELTA_Y * level / 100));
+        final Double actualPosition = gridLienzoScrollPosition.currentPositionY(level);
+
+        assertEquals(expectedPosition,
+                     actualPosition,
+                     0);
+    }
+
+    @Test
+    public void testGetVisibleBounds() {
+
+        final Bounds expectedBounds = mock(Bounds.class);
+
+        doReturn(expectedBounds).when(defaultGridLayer).getVisibleBounds();
+        doCallRealMethod().when(gridLienzoScrollPosition).getVisibleBounds();
+
+        final Bounds actualBounds = gridLienzoScrollPosition.getVisibleBounds();
+
+        assertEquals(expectedBounds,
+                     actualBounds);
+    }
+
+    @Test
+    public void testGetTransform() {
+
+        final Viewport viewport = mock(Viewport.class);
+        final Transform expectedTransform = mock(Transform.class);
+
+        doReturn(viewport).when(defaultGridLayer).getViewport();
+        doReturn(expectedTransform).when(viewport).getTransform();
+        doCallRealMethod().when(gridLienzoScrollPosition).getTransform();
+
+        final Transform actualTransform = gridLienzoScrollPosition.getTransform();
+
+        assertEquals(expectedTransform,
+                     actualTransform);
+    }
+
+    @Test
+    public void testBounds() {
+
+        doCallRealMethod().when(gridLienzoScrollPosition).bounds();
+
+        assertTrue(gridLienzoScrollPosition.bounds() != null);
+    }
+
+    private GridLienzoScrollBounds makeScrollBoundsHelper() {
+
+        final GridLienzoScrollBounds gridLienzoScrollBounds = mock(GridLienzoScrollBounds.class);
+
+        doReturn(MAX_BOUND_X).when(gridLienzoScrollBounds).maxBoundX();
+        doReturn(MAX_BOUND_Y).when(gridLienzoScrollBounds).maxBoundY();
+        doReturn(MIN_BOUND_X).when(gridLienzoScrollBounds).minBoundX();
+        doReturn(MIN_BOUND_Y).when(gridLienzoScrollBounds).minBoundY();
+
+        return gridLienzoScrollBounds;
+    }
+
+    private Bounds makeVisibleBounds() {
+
+        final Bounds bounds = mock(Bounds.class);
+
+        doReturn(VISIBLE_BOUND_WIDTH).when(bounds).getWidth();
+        doReturn(VISIBLE_BOUND_HEIGHT).when(bounds).getHeight();
+
+        return bounds;
+    }
+
+    private Transform makeTransform() {
+
+        final Transform transform = mock(Transform.class);
+
+        doReturn(TRANSLATE_X).when(transform).getTranslateX();
+        doReturn(TRANSLATE_Y).when(transform).getTranslateY();
+        doReturn(SCALE_X).when(transform).getScaleX();
+        doReturn(SCALE_Y).when(transform).getScaleY();
+
+        return transform;
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollUITest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/scrollbars/GridLienzoScrollUITest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.core.grids.client.widget.scrollbars;
+
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.ui.AbsolutePanel;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class GridLienzoScrollUITest {
+
+    @Mock
+    private AbsolutePanel panel;
+
+    @Mock
+    private Style style;
+
+    @Mock
+    private GridLienzoScrollHandler gridLienzoScrollHandler;
+
+    private GridLienzoScrollUI gridLienzoScrollUI;
+
+    @Before
+    public void setUp() {
+        this.gridLienzoScrollUI = spy(new GridLienzoScrollUI(gridLienzoScrollHandler));
+
+        doReturn(style).when(gridLienzoScrollUI).style(any());
+    }
+
+    @Test
+    public void testSetup() {
+
+        gridLienzoScrollUI.setup();
+
+        verify(gridLienzoScrollUI).applyMainPanelStyle();
+        verify(gridLienzoScrollUI).applyMakeInternalScrollPanel();
+        verify(gridLienzoScrollUI).applyDomElementContainerStyle();
+    }
+
+    @Test
+    public void testApplyMainPanelStyle() {
+
+        gridLienzoScrollUI.applyMainPanelStyle();
+
+        verify(style).setPosition(Style.Position.RELATIVE);
+        verify(style).setOverflow(Style.Overflow.SCROLL);
+        verify(style).setZIndex(1);
+    }
+
+    @Test
+    public void testApplyMakeInternalScrollPanel() {
+
+        gridLienzoScrollUI.applyMakeInternalScrollPanel();
+
+        verify(style).setPosition(Style.Position.ABSOLUTE);
+    }
+
+    @Test
+    public void testApplyDomElementContainerStyle() {
+
+        doReturn(style).when(gridLienzoScrollUI).style(any());
+
+        gridLienzoScrollUI.applyDomElementContainerStyle();
+
+        verify(style).setPosition(Style.Position.FIXED);
+    }
+
+    @Test
+    public void testStyle() {
+
+        final Widget widget = mock(Widget.class);
+        final Element element = mock(Element.class);
+        final Style expectedStyle = mock(Style.class);
+
+        doReturn(expectedStyle).when(element).getStyle();
+        doReturn(element).when(widget).getElement();
+        doCallRealMethod().when(gridLienzoScrollUI).style(any());
+
+        final Style actualStyle = gridLienzoScrollUI.style(widget);
+
+        assertEquals(expectedStyle,
+                     actualStyle);
+    }
+}


### PR DESCRIPTION
Cherry picked from https://github.com/AppFormer/uberfire/pull/808

---

Part of an ensemble:
- https://github.com/kiegroup/drools-wb/pull/594
- https://github.com/AppFormer/uberfire/pull/819

---

PS: We don't need to update `kie-wb-common` on `7.3.x`.