### PR TITLE
Skip WildFly dist unpacking when skipping GWT compilation

### DIFF
--- a/uberfire-showcase/uberfire-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-webapp/pom.xml
@@ -468,6 +468,7 @@
                   <outputDirectory>${project.build.directory}</outputDirectory>
                 </artifactItem>
               </artifactItems>
+              <skip>${gwt.compiler.skip}</skip>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
No need to unpack the WildFly distribution when the GWT compilation is
skipped. It is not being used and only slows down the build (and takes
additional disk space)