### PR TITLE
[1.3.x] JBPM-6238: NPE error thrown when switching the number of items per page

### DIFF
--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/tables/PagedTable.java
@@ -104,6 +104,7 @@ public class PagedTable<T>
               gridGlobalPreferences);
         this.showPageSizesSelector = showPageSizesSelector;
         this.pageSize = pageSize;
+        this.dataGrid.setPageStart(0);
         this.dataGrid.setPageSize(pageSize);
         PagedTableHelper.setSelectedValue(pageSizesSelector,
                                           String.valueOf(pageSize));
@@ -140,6 +141,7 @@ public class PagedTable<T>
 
     public final void loadPageSizePreferences() {
         pageSize = getPageSizeStored();
+        this.dataGrid.setPageStart(0);
         this.dataGrid.setPageSize(pageSize);
         this.pager.setPageSize(pageSize);
         int height = ((pageSize <= 0 ? 1 : pageSize) * ROW_HEIGHT_PX) + HEIGHT_OFFSET_PX;

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/tables/PagedTableTest.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/tables/PagedTableTest.java
@@ -54,5 +54,19 @@ public class PagedTableTest {
         pagedTable.loadPageSizePreferences();
         verify(pagedTable.dataGrid, times(1)).setHeight(eq(EXPECTED_HEIGHT_PX + "px"));
     }
+
+    @Test
+    public void testLoadPageSizePreferencesResetsPageStart() throws Exception {
+        final int PAGE_SIZE = 10;
+
+        PagedTable pagedTable = new PagedTable(PAGE_SIZE);
+        pagedTable.dataGrid = spy(pagedTable.dataGrid);
+
+        verify(pagedTable.dataGrid, times(0)).setPageStart(0);
+
+        pagedTable.loadPageSizePreferences();
+        verify(pagedTable.dataGrid, times(1)).setPageStart(0);
+    }
+
     
 }


### PR DESCRIPTION
reset currentPage to the first one when the page size is changed