### PR TITLE
GUVNOR-2825: [Guided Decision Table] Hints are empty

### DIFF
--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/InfoPopup.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/InfoPopup.java
@@ -15,12 +15,13 @@
  */
 package org.uberfire.ext.widgets.common.client.common;
 
-import com.google.gwt.dom.client.Element;
 import org.gwtbootstrap3.client.ui.Icon;
 import org.gwtbootstrap3.client.ui.Popover;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.client.ui.constants.Placement;
 import org.gwtbootstrap3.client.ui.constants.Trigger;
+
+import com.google.gwt.dom.client.Element;
 
 /**
  * This is handy for in-place context help.
@@ -28,15 +29,16 @@ import org.gwtbootstrap3.client.ui.constants.Trigger;
 public class InfoPopup extends Popover {
 
     public InfoPopup(final String text) {
+        super(text);
         configure();
-        setContent(text);
+        recreate();
     }
 
     public InfoPopup(final String heading,
                      final String text) {
+        super(heading, text);
         configure();
-        setTitle(heading);
-        setContent(text);
+        recreate();
     }
 
     private void configure() {
@@ -47,13 +49,13 @@ public class InfoPopup extends Popover {
         icon.addStyleName("help-inline");
         setWidget(icon);
 
-        configurePopoverContainer(this.getWidget().getElement());
+        configurePopoverContainer(getWidget().getElement());
         getWidget().getElement().getStyle().setZIndex(Integer.MAX_VALUE);
     }
 
     private native void configurePopoverContainer(Element e) /*-{
-        $wnd.jQuery(e).popover({
-            container: 'body'
-        });
-    }-*/;
+                                                             $wnd.jQuery(e).popover({
+                                                             container: 'body'
+                                                             });
+                                                             }-*/;
 }

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/common/InfoPopupTest.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/common/InfoPopupTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.widgets.common.client.common;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+/**
+ * Test InfoPopup is initialized correctly for each constructor.
+ *
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class InfoPopupTest {
+
+    private InfoPopup infoPopup;
+    private boolean infoPopupRecreated;
+
+    @Before
+    public void setup() {
+        infoPopupRecreated = false;
+    }
+
+    @Test
+    public void testRecreate_1() {
+
+        infoPopup = new InfoPopup("title") {
+
+            @Override
+            public void recreate() {
+                super.recreate();
+                infoPopupRecreated = true;
+            }
+        };
+        assertTrue(infoPopupRecreated);
+
+    }
+
+    @Test
+    public void testRecreate_2() {
+
+        infoPopup = new InfoPopup("title", "content") {
+
+            @Override
+            public void recreate() {
+                super.recreate();
+                infoPopupRecreated = true;
+            }
+        };
+        assertTrue(infoPopupRecreated);
+
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2825

Setting title/content via super class constructor and calling recreate method.  The init() method of Popover class was never being called from InfoPopup so help messages were never displayed.

If the formatting is not liked don't blame me!  It is the latest Eclipse formatter.