### PR TITLE
[7.3.x] AF-615: Items in the logout menu duplicated every time navigation tree is changed

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/menu/UserMenu.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/menu/UserMenu.java
@@ -103,8 +103,14 @@ public class UserMenu implements MenuFactory.CustomMenuBuilder,
         };
     }
 
+    public void clear() {
+        userMenuView.clearMenuItems();
+    }
+
     public interface UserMenuView extends HasMenuItems {
 
         void setUserName(String userName);
+
+        void clearMenuItems();
     }
 }

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/menu/UserMenuViewImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/menu/UserMenuViewImpl.java
@@ -62,6 +62,11 @@ public class UserMenuViewImpl extends AnchorListItem implements UserMenu.UserMen
     }
 
     @Override
+    public void clearMenuItems() {
+        menu.clear();
+    }
+
+    @Override
     public void addMenuItem(final MenuPosition position,
                             final Widget menuContent) {
         //Always add new option on top

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/menu/UserMenuTest.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/menu/UserMenuTest.java
@@ -74,4 +74,10 @@ public class UserMenuTest {
         userMenu.setup();
         verify(userMenuView).setUserName(lastName);
     }
+
+    @Test
+    public void testClear() {
+        userMenu.clear();
+        verify(userMenuView).clearMenuItems();
+    }
 }


### PR DESCRIPTION
Cherry-picked from [master](https://github.com/AppFormer/uberfire/pull/840)