### PR TITLE
AF-477: [Security management] Security setting changes are lost if perspective is changed

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/src/main/java/org/uberfire/ext/security/management/client/screens/editor/GroupEditorScreen.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/src/main/java/org/uberfire/ext/security/management/client/screens/editor/GroupEditorScreen.java
@@ -23,6 +23,7 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import org.jboss.errai.common.client.dom.Window;
 import org.uberfire.client.annotations.WorkbenchContextId;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
@@ -31,12 +32,14 @@ import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.security.management.client.ClientUserSystemManager;
+import org.uberfire.ext.security.management.client.resources.i18n.UsersManagementWidgetsConstants;
 import org.uberfire.ext.security.management.client.resources.i18n.UsersManagementWorkbenchConstants;
 import org.uberfire.ext.security.management.client.screens.BaseScreen;
 import org.uberfire.ext.security.management.client.widgets.management.editor.group.workflow.GroupCreationWorkflow;
 import org.uberfire.ext.security.management.client.widgets.management.editor.group.workflow.GroupEditorWorkflow;
 import org.uberfire.ext.security.management.client.widgets.management.events.DeleteGroupEvent;
 import org.uberfire.lifecycle.OnClose;
+import org.uberfire.lifecycle.OnMayClose;
 import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
@@ -94,6 +97,12 @@ public class GroupEditorScreen {
     @OnOpen
     public void onOpen() {
 
+    }
+
+    @OnMayClose
+    public boolean onMayClose() {
+        return !groupEditorWorkflow.isDirty() ||
+                Window.confirm(UsersManagementWidgetsConstants.INSTANCE.groupIsDirty());
     }
 
     @OnClose

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/src/main/java/org/uberfire/ext/security/management/client/screens/editor/RoleEditorScreen.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/src/main/java/org/uberfire/ext/security/management/client/screens/editor/RoleEditorScreen.java
@@ -22,6 +22,7 @@ import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import org.jboss.errai.common.client.dom.Window;
 import org.uberfire.client.annotations.WorkbenchContextId;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
@@ -30,10 +31,12 @@ import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.security.management.client.ClientUserSystemManager;
+import org.uberfire.ext.security.management.client.resources.i18n.UsersManagementWidgetsConstants;
 import org.uberfire.ext.security.management.client.resources.i18n.UsersManagementWorkbenchConstants;
 import org.uberfire.ext.security.management.client.screens.BaseScreen;
 import org.uberfire.ext.security.management.client.widgets.management.editor.role.workflow.RoleEditorWorkflow;
 import org.uberfire.lifecycle.OnClose;
+import org.uberfire.lifecycle.OnMayClose;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
 
@@ -73,6 +76,12 @@ public class RoleEditorScreen {
         roleName = placeRequest.getParameter(ROLE_NAME,
                                              null);
         show();
+    }
+
+    @OnMayClose
+    public boolean onMayClose() {
+        return !roleEditorWorkflow.isDirty() ||
+                Window.confirm(UsersManagementWidgetsConstants.INSTANCE.roleIsDirty());
     }
 
     @OnClose

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/src/main/java/org/uberfire/ext/security/management/client/screens/editor/UserEditorScreen.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/src/main/java/org/uberfire/ext/security/management/client/screens/editor/UserEditorScreen.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.ui.IsWidget;
+import org.jboss.errai.common.client.dom.Window;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.uberfire.client.annotations.WorkbenchContextId;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
@@ -33,6 +34,7 @@ import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
 import org.uberfire.client.workbench.widgets.common.ErrorPopupPresenter;
 import org.uberfire.ext.security.management.client.ClientUserSystemManager;
+import org.uberfire.ext.security.management.client.resources.i18n.UsersManagementWidgetsConstants;
 import org.uberfire.ext.security.management.client.resources.i18n.UsersManagementWorkbenchConstants;
 import org.uberfire.ext.security.management.client.screens.BaseScreen;
 import org.uberfire.ext.security.management.client.widgets.management.editor.user.workflow.UserCreationWorkflow;
@@ -42,6 +44,7 @@ import org.uberfire.ext.security.management.client.widgets.management.events.Del
 import org.uberfire.ext.security.management.client.widgets.management.events.OnEditEvent;
 import org.uberfire.ext.security.management.client.widgets.management.events.OnShowEvent;
 import org.uberfire.lifecycle.OnClose;
+import org.uberfire.lifecycle.OnMayClose;
 import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 import org.uberfire.mvp.PlaceRequest;
@@ -99,6 +102,12 @@ public class UserEditorScreen {
     @OnOpen
     public void onOpen() {
 
+    }
+
+    @OnMayClose
+    public boolean onMayClose() {
+        return !isDirty() ||
+                Window.confirm(UsersManagementWidgetsConstants.INSTANCE.userIsDirty());
     }
 
     @OnClose
@@ -175,6 +184,10 @@ public class UserEditorScreen {
     private boolean checkEventContext(final ContextualEvent contextualEvent,
                                       final Object context) {
         return contextualEvent != null && contextualEvent.getContext() != null && contextualEvent.getContext().equals(context);
+    }
+
+    private boolean isDirty() {
+        return userEditorWorkflow.isDirty() || userCreationWorkflow.isDirty();
     }
 
     void closeEditor() {

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/src/test/java/org/uberfire/ext/security/management/client/screens/editor/GroupEditorScreenTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/src/test/java/org/uberfire/ext/security/management/client/screens/editor/GroupEditorScreenTest.java
@@ -53,7 +53,7 @@ public class GroupEditorScreenTest {
     @Mock
     ClientUserSystemManager clientUserSystemManager;
     @Mock
-    GroupEditorWorkflow groupViewerWorkflow;
+    GroupEditorWorkflow groupEditorWorkflow;
     @Mock
     GroupCreationWorkflow groupCreationWorkflow;
     @Mock
@@ -87,9 +87,21 @@ public class GroupEditorScreenTest {
                                        isNull(String.class))).thenReturn("group1");
         tested.onStartup(placeRequest);
         verify(baseScreen,
-               times(1)).init(groupViewerWorkflow);
-        verify(groupViewerWorkflow,
+               times(1)).init(groupEditorWorkflow);
+        verify(groupEditorWorkflow,
                times(1)).show("group1");
+    }
+
+    @Test
+    public void testOnMayCloseSuccess() {
+        when(groupEditorWorkflow.isDirty()).thenReturn(false);
+        assertTrue(tested.onMayClose());
+    }
+
+    @Test
+    public void testOnMayCloseFailed() {
+        when(groupEditorWorkflow.isDirty()).thenReturn(true);
+        assertFalse(tested.onMayClose());
     }
 
     @Test
@@ -97,7 +109,7 @@ public class GroupEditorScreenTest {
         tested.groupName = "group1";
         tested.onClose();
         assertNull(tested.groupName);
-        verify(groupViewerWorkflow,
+        verify(groupEditorWorkflow,
                times(1)).clear();
         verify(groupCreationWorkflow,
                times(1)).clear();

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/src/test/java/org/uberfire/ext/security/management/client/screens/editor/RoleEditorScreenTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/src/test/java/org/uberfire/ext/security/management/client/screens/editor/RoleEditorScreenTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.management.client.screens.editor;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.uberfire.ext.security.management.api.Capability;
+import org.uberfire.ext.security.management.client.ClientUserSystemManager;
+import org.uberfire.ext.security.management.client.widgets.management.editor.role.workflow.RoleEditorWorkflow;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class RoleEditorScreenTest {
+
+    @Mock
+    ClientUserSystemManager clientUserSystemManager;
+
+    @Mock
+    RoleEditorWorkflow roleEditorWorkflow;
+
+    @InjectMocks
+    RoleEditorScreen tested;
+
+    @Before
+    public void setup() {
+        when(clientUserSystemManager.isUserCapabilityEnabled(any(Capability.class))).thenReturn(true);
+    }
+
+    @Test
+    public void testOnMayCloseSuccess() {
+        when(roleEditorWorkflow.isDirty()).thenReturn(false);
+        assertTrue(tested.onMayClose());
+    }
+
+    @Test
+    public void testOnMayCloseFailed() {
+        when(roleEditorWorkflow.isDirty()).thenReturn(true);
+        assertFalse(tested.onMayClose());
+    }
+}

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/src/test/java/org/uberfire/ext/security/management/client/screens/editor/UserEditorScreenTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-client-wb/src/test/java/org/uberfire/ext/security/management/client/screens/editor/UserEditorScreenTest.java
@@ -100,6 +100,26 @@ public class UserEditorScreenTest {
     }
 
     @Test
+    public void testOnMayCloseSuccess() {
+        when(userEditorWorkflow.isDirty()).thenReturn(false);
+        when(userCreationWorkflow.isDirty()).thenReturn(false);
+        assertTrue(tested.onMayClose());
+    }
+
+    @Test
+    public void testOnMayCloseFailed() {
+        when(userEditorWorkflow.isDirty()).thenReturn(true);
+        when(userCreationWorkflow.isDirty()).thenReturn(true);
+        assertFalse(tested.onMayClose());
+        when(userEditorWorkflow.isDirty()).thenReturn(false);
+        when(userCreationWorkflow.isDirty()).thenReturn(true);
+        assertFalse(tested.onMayClose());
+        when(userEditorWorkflow.isDirty()).thenReturn(true);
+        when(userCreationWorkflow.isDirty()).thenReturn(false);
+        assertFalse(tested.onMayClose());
+    }
+
+    @Test
     public void testOnClose() {
         tested.userId = "user1";
         tested.onClose();

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupEditorWorkflow.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/group/workflow/GroupEditorWorkflow.java
@@ -152,6 +152,10 @@ public class GroupEditorWorkflow implements IsWidget {
         group = null;
     }
 
+    public boolean isDirty() {
+        return isDirty;
+    }
+
     /*  ******************************************************************************************************
                                  PROTECTED PRESENTER API
      ****************************************************************************************************** */

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/role/workflow/BaseRoleEditorWorkflow.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/role/workflow/BaseRoleEditorWorkflow.java
@@ -112,7 +112,14 @@ public abstract class BaseRoleEditorWorkflow implements IsWidget {
          ****************************************************************************************************** */
 
     public void clear() {
-        checkDirty(this::doClear);
+        view.clearNotification();
+        roleEditor.clear();
+        isDirty = false;
+        role = null;
+    }
+
+    public boolean isDirty() {
+        return isDirty;
     }
 
     protected void doShow(final String roleName) {
@@ -126,7 +133,7 @@ public abstract class BaseRoleEditorWorkflow implements IsWidget {
     }
 
     protected void doLoad(String roleName) {
-        clear();
+        checkDirty(this::clear);
 
         // Call backend service.
         showLoadingBox();
@@ -230,12 +237,6 @@ public abstract class BaseRoleEditorWorkflow implements IsWidget {
         } else {
             throw new RuntimeException("Role must be valid before updating it.");
         }
-    }
-
-    protected void doClear() {
-        view.clearNotification();
-        roleEditor.clear();
-        role = null;
     }
 
     protected boolean checkEventContext(final ContextualEvent contextualEvent,

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/user/workflow/BaseUserEditorWorkflow.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/user/workflow/BaseUserEditorWorkflow.java
@@ -120,7 +120,7 @@ public abstract class BaseUserEditorWorkflow implements IsWidget {
         checkDirty(new Command() {
             @Override
             public void execute() {
-                clear();
+                checkClear();
                 // Call backend service.
                 showLoadingBox();
                 userSystemManager.users(new RemoteCallback<User>() {
@@ -142,16 +142,18 @@ public abstract class BaseUserEditorWorkflow implements IsWidget {
     }
 
     public void clear() {
-        checkDirty(new Command() {
-            @Override
-            public void execute() {
-                doClear();
-            }
-        });
+        view.clearNotification();
+        userEditor.clear();
+        user = null;
+        setDirty(false);
     }
 
     public UserEditor getUserEditor() {
         return userEditor;
+    }
+
+    public boolean isDirty() {
+        return isDirty;
     }
 
     protected void onSave() {
@@ -298,7 +300,7 @@ public abstract class BaseUserEditorWorkflow implements IsWidget {
                                                                     deleteUserEvent.fire(new DeleteUserEvent(id));
                                                                     workbenchNotification.fire(new NotificationEvent(UsersManagementWidgetsConstants.INSTANCE.userRemoved(id),
                                                                                                                      SUCCESS));
-                                                                    clear();
+                                                                    checkClear();
                                                                 }
                                                             },
                                                             errorCallback).delete(id);
@@ -338,13 +340,6 @@ public abstract class BaseUserEditorWorkflow implements IsWidget {
         return result;
     }
 
-    protected void doClear() {
-        view.clearNotification();
-        userEditor.clear();
-        user = null;
-        setDirty(false);
-    }
-
     protected boolean checkEventContext(final ContextualEvent contextualEvent,
                                         final Object context) {
         return contextualEvent != null && contextualEvent.getContext() != null && contextualEvent.getContext().equals(context);
@@ -353,6 +348,10 @@ public abstract class BaseUserEditorWorkflow implements IsWidget {
     protected void showError(final Throwable throwable) {
         errorEvent.fire(new OnErrorEvent(BaseUserEditorWorkflow.this,
                                          throwable));
+    }
+
+    protected void checkClear() {
+        checkDirty(this::clear);
     }
 
     protected void checkDirty(final Command callback) {

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/user/workflow/UserCreationWorkflow.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/user/workflow/UserCreationWorkflow.java
@@ -108,7 +108,7 @@ public class UserCreationWorkflow extends BaseUserEditorWorkflow {
          ****************************************************************************************************** */
 
     public void create() {
-        clear();
+        checkClear();
 
         // Permissions can not be shown until the user is created
         getUserEditor().setPermissionsVisible(false);
@@ -276,8 +276,8 @@ public class UserCreationWorkflow extends BaseUserEditorWorkflow {
     }
 
     @Override
-    protected void doClear() {
-        super.doClear();
+    public void clear() {
+        super.clear();
         createEntity.clear();
     }
 


### PR DESCRIPTION
Hey @manstis @tomasdavidorg 

Promised this is the last one urgent for the LA release... can you please take a look at it? :) I'll do the cherry-pick once merged.

[See here](https://issues.jboss.org/browse/AF-477) the JIRA ticket for this bug.

Notice I did not found any other way rather than using the `confirm` method from the `Window` jsinterop API to  implement the screens' `@OnMayClose`, as the popup that the users management ui uses (from uberfire) seems to be a modal and is not possible to return the right value. So finally just did as the workbench Editors' do, show a native confirm box.

It **depends on** https://github.com/errai/errai/pull/292

Thanks!
 