### PR TITLE
GUVNOR-3524: Do not expose unsupported features by UI (e.g. scorecards, decision trees)

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/authz/EditorTreeProvider.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/authz/EditorTreeProvider.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.authz;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.uberfire.client.mvp.Activity;
+import org.uberfire.client.mvp.ActivityBeansCache;
+import org.uberfire.client.mvp.WorkbenchEditorActivity;
+import org.uberfire.client.resources.i18n.PermissionTreeI18n;
+import org.uberfire.security.Resource;
+import org.uberfire.security.ResourceAction;
+import org.uberfire.security.authz.Permission;
+import org.uberfire.security.authz.PermissionManager;
+import org.uberfire.security.client.authz.tree.LoadCallback;
+import org.uberfire.security.client.authz.tree.LoadOptions;
+import org.uberfire.security.client.authz.tree.PermissionNode;
+import org.uberfire.security.client.authz.tree.PermissionTreeProvider;
+import org.uberfire.security.client.authz.tree.impl.PermissionLeafNode;
+import org.uberfire.security.client.authz.tree.impl.PermissionResourceNode;
+import org.uberfire.workbench.model.ActivityResourceType;
+
+import static org.uberfire.client.authz.PerspectiveAction.READ;
+
+@ApplicationScoped
+public class EditorTreeProvider implements PermissionTreeProvider {
+
+    private ActivityBeansCache activityBeansCache;
+    private PermissionManager permissionManager;
+    private PermissionTreeI18n i18n;
+    private String resourceName = null;
+    private String rootNodeName = null;
+    private int rootNodePosition = 0;
+    private Set<RegisteredEditor> registeredEditors = new HashSet<>();
+
+    public EditorTreeProvider() {
+        //CDI proxy
+    }
+
+    @Inject
+    public EditorTreeProvider(final ActivityBeansCache activityBeansCache,
+                              final PermissionManager permissionManager,
+                              final PermissionTreeI18n i18n) {
+        this.activityBeansCache = activityBeansCache;
+        this.permissionManager = permissionManager;
+        this.i18n = i18n;
+        this.resourceName = i18n.editorResourceName();
+        this.rootNodeName = i18n.editorsNodeName();
+    }
+
+    @Override
+    public PermissionNode buildRootNode() {
+        final PermissionResourceNode rootNode = new PermissionResourceNode(resourceName,
+                                                                           this);
+        rootNode.setNodeName(rootNodeName);
+        rootNode.setPositionInTree(rootNodePosition);
+        rootNode.setNodeFullName(i18n.editorsNodeHelp());
+        rootNode.addPermission(newPermission(READ),
+                               i18n.editorRead());
+
+        return rootNode;
+    }
+
+    @Override
+    public void loadChildren(final PermissionNode parent,
+                             final LoadOptions options,
+                             final LoadCallback callback) {
+        if (parent.getNodeName().equals(rootNodeName)) {
+            callback.afterLoad(buildEditorNodes(options));
+        }
+    }
+
+    public int getRootNodePosition() {
+        return rootNodePosition;
+    }
+
+    public void setRootNodePosition(int rootNodePosition) {
+        this.rootNodePosition = rootNodePosition;
+    }
+
+    public void registerEditor(final String editorId,
+                               final String editorName) {
+        final SyncBeanDef<Activity> editorBeanDef = activityBeansCache.getActivity(editorId);
+        if (editorBeanDef != null) {
+            final WorkbenchEditorActivity editor = (WorkbenchEditorActivity) editorBeanDef.getInstance();
+            registeredEditors.add(new RegisteredEditor(editorId,
+                                                       editorName,
+                                                       editor));
+        }
+    }
+
+    private Permission newPermission(final ResourceAction action) {
+        return permissionManager.createPermission(ActivityResourceType.EDITOR,
+                                                  action,
+                                                  true);
+    }
+
+    private Permission newPermission(final Resource resource,
+                                     final ResourceAction action) {
+        return permissionManager.createPermission(resource,
+                                                  action,
+                                                  true);
+    }
+
+    private List<PermissionNode> buildEditorNodes(final LoadOptions options) {
+        final List<PermissionNode> nodes = new ArrayList<>();
+        registeredEditors.stream()
+                .filter(e -> match(e, options))
+                .forEach(e -> nodes.add(toEditorNode(e)));
+
+        final int max = options.getMaxNodes();
+        return max > 0 && max < nodes.size() ? nodes.subList(0,
+                                                             max) : nodes;
+    }
+
+    private PermissionNode toEditorNode(final RegisteredEditor editor) {
+        final PermissionLeafNode node = new PermissionLeafNode();
+        node.setNodeName(editor.editorName);
+
+        final Permission readPermission = newPermission(editor.activity,
+                                                        READ);
+        node.addPermission(readPermission,
+                           i18n.editorRead());
+
+        return node;
+    }
+
+    private boolean match(final RegisteredEditor editor,
+                          final LoadOptions options) {
+        final String identifier = editor.editorId;
+        final String namePattern = options.getNodeNamePattern();
+        final Collection<String> includedIds = options.getResourceIds();
+
+        if (includedIds != null && !includedIds.isEmpty()) {
+            if (includedIds.contains(identifier)) {
+                return true;
+            }
+        }
+        if (namePattern != null) {
+            final String editorName = editor.editorName;
+            if (editorName.toLowerCase().contains(namePattern.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private class RegisteredEditor {
+
+        private String editorId;
+        private String editorName;
+        private WorkbenchEditorActivity activity;
+
+        public RegisteredEditor(final String editorId,
+                                final String editorName,
+                                final WorkbenchEditorActivity activity) {
+            this.editorId = editorId;
+            this.editorName = editorName;
+            this.activity = activity;
+        }
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/resources/i18n/PermissionTreeI18NImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/resources/i18n/PermissionTreeI18NImpl.java
@@ -55,4 +55,24 @@ public class PermissionTreeI18NImpl implements PermissionTreeI18n {
     public String perspectiveDelete() {
         return PermissionTreeConstants.INSTANCE.perspectiveDelete();
     }
+
+    @Override
+    public String editorsNodeName() {
+        return PermissionTreeConstants.INSTANCE.editorsNodeName();
+    }
+
+    @Override
+    public String editorsNodeHelp() {
+        return PermissionTreeConstants.INSTANCE.editorsNodeHelp();
+    }
+
+    @Override
+    public String editorResourceName() {
+        return PermissionTreeConstants.INSTANCE.editorResourceName();
+    }
+
+    @Override
+    public String editorRead() {
+        return PermissionTreeConstants.INSTANCE.editorRead();
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/resources/i18n/PermissionTreeI18n.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/resources/i18n/PermissionTreeI18n.java
@@ -31,4 +31,12 @@ public interface PermissionTreeI18n {
     String perspectiveUpdate();
 
     String perspectiveDelete();
+
+    String editorsNodeName();
+
+    String editorsNodeHelp();
+
+    String editorResourceName();
+
+    String editorRead();
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/resources/org/uberfire/client/resources/i18n/PermissionTreeConstants.properties
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/resources/org/uberfire/client/resources/i18n/PermissionTreeConstants.properties
@@ -21,3 +21,7 @@ perspectiveCreate=Create
 perspectiveRead=Read
 perspectiveUpdate=Update
 perspectiveDelete=Delete
+editorsNodeName=Editors
+editorsNodeHelp=If access to an editor is denied then it will not be shown in any of application menus.
+editorResourceName=Editor
+editorRead=Read

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/authz/EditorTreeProviderTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/authz/EditorTreeProviderTest.java
@@ -17,6 +17,7 @@ package org.uberfire.client.authz;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.junit.Before;
@@ -37,6 +38,7 @@ import org.uberfire.security.impl.authz.DefaultPermissionManager;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -106,10 +108,8 @@ public class EditorTreeProviderTest {
         options.setResourceIds(Collections.singletonList(EDITOR1_ID));
         provider.loadChildren(root,
                               options,
-                              children -> {
-                                  assertEquals(children.size(),
-                                               1);
-                              });
+                              children -> assertEquals(children.size(),
+                                                       1));
     }
 
     @Test
@@ -134,8 +134,22 @@ public class EditorTreeProviderTest {
         options.setNodeNamePattern("name");
         provider.loadChildren(root,
                               options,
-                              children -> assertEquals(children.size(),
-                                                       2));
+                              children -> {
+                                  assertEquals(children.size(),
+                                               2);
+                                  assertContains(EDITOR1_NAME,
+                                                 children);
+                                  assertContains(EDITOR2_NAME,
+                                                 children);
+                              });
+    }
+
+    private void assertContains(final String editorName,
+                                final List<PermissionNode> children) {
+        assertTrue(children.stream()
+                           .filter(p -> p.getNodeName().equals(editorName))
+                           .findFirst()
+                           .isPresent());
     }
 
     @Test
@@ -151,6 +165,8 @@ public class EditorTreeProviderTest {
                               children -> {
                                   assertEquals(children.size(),
                                                1);
+                                  assertEquals(EDITOR1_NAME,
+                                               children.get(0).getNodeName());
                               });
     }
 
@@ -167,6 +183,8 @@ public class EditorTreeProviderTest {
                               children -> {
                                   assertEquals(children.size(),
                                                1);
+                                  assertEquals(EDITOR2_NAME,
+                                               children.get(0).getNodeName());
                               });
     }
 

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/authz/EditorTreeProviderTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/authz/EditorTreeProviderTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.authz;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.client.mvp.Activity;
+import org.uberfire.client.mvp.ActivityBeansCache;
+import org.uberfire.client.mvp.WorkbenchEditorActivity;
+import org.uberfire.client.resources.i18n.PermissionTreeI18n;
+import org.uberfire.security.authz.Permission;
+import org.uberfire.security.authz.PermissionManager;
+import org.uberfire.security.client.authz.tree.PermissionNode;
+import org.uberfire.security.client.authz.tree.PermissionTree;
+import org.uberfire.security.client.authz.tree.impl.DefaultLoadOptions;
+import org.uberfire.security.impl.authz.DefaultPermissionManager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EditorTreeProviderTest {
+
+    private static final String EDITOR1_ID = "Editor1";
+    private static final String EDITOR2_ID = "Editor2";
+    private static final String EDITOR1_NAME = "Editor 1 name";
+    private static final String EDITOR2_NAME = "Editor 2 name";
+
+    @Mock
+    private ActivityBeansCache activityBeansCache;
+
+    @Mock
+    private PermissionTreeI18n i18n;
+
+    @Mock
+    private PermissionTree permissionTree;
+
+    private PermissionManager permissionManager;
+    private EditorTreeProvider provider;
+    private PermissionNode root;
+
+    @Before
+    public void setUp() {
+        final SyncBeanDef<Activity> editor1 = makeWorkbenchEditorActivity(EDITOR1_ID);
+        final SyncBeanDef<Activity> editor2 = makeWorkbenchEditorActivity(EDITOR2_ID);
+        when(activityBeansCache.getActivity(EDITOR1_ID)).thenReturn(editor1);
+        when(activityBeansCache.getActivity(EDITOR2_ID)).thenReturn(editor2);
+
+        when(i18n.editorResourceName()).thenReturn("Editor Resource name");
+        when(i18n.editorsNodeName()).thenReturn("Editor Node name");
+
+        permissionManager = new DefaultPermissionManager();
+        provider = new EditorTreeProvider(activityBeansCache,
+                                          permissionManager,
+                                          i18n);
+
+        root = provider.buildRootNode();
+        root.setPermissionTree(permissionTree);
+    }
+
+    @SuppressWarnings("unchecked")
+    private SyncBeanDef<Activity> makeWorkbenchEditorActivity(final String editorId) {
+        final SyncBeanDef<Activity> beanDef = mock(SyncBeanDef.class);
+        final WorkbenchEditorActivity bean = mock(WorkbenchEditorActivity.class);
+        when(beanDef.getInstance()).thenReturn(bean);
+        when(bean.getIdentifier()).thenReturn(editorId);
+        return beanDef;
+    }
+
+    @Test
+    public void testEmpty() {
+        final DefaultLoadOptions options = new DefaultLoadOptions();
+        provider.loadChildren(root,
+                              options,
+                              children -> assertEquals(children.size(),
+                                                       0));
+    }
+
+    @Test
+    public void testIncludedResourceIds() {
+        provider.registerEditor(EDITOR1_ID,
+                                EDITOR1_NAME);
+        final DefaultLoadOptions options = new DefaultLoadOptions();
+        options.setResourceIds(Collections.singletonList(EDITOR1_ID));
+        provider.loadChildren(root,
+                              options,
+                              children -> {
+                                  assertEquals(children.size(),
+                                               1);
+                              });
+    }
+
+    @Test
+    public void testRegisterEditor() {
+        provider.registerEditor(EDITOR1_ID,
+                                EDITOR1_NAME);
+        final DefaultLoadOptions options = new DefaultLoadOptions();
+        options.setNodeNamePattern("");
+        provider.loadChildren(root,
+                              options,
+                              children -> assertEquals(children.size(),
+                                                       1));
+    }
+
+    @Test
+    public void testNameSearch1() {
+        provider.registerEditor(EDITOR1_ID,
+                                EDITOR1_NAME);
+        provider.registerEditor(EDITOR2_ID,
+                                EDITOR2_NAME);
+        final DefaultLoadOptions options = new DefaultLoadOptions();
+        options.setNodeNamePattern("name");
+        provider.loadChildren(root,
+                              options,
+                              children -> assertEquals(children.size(),
+                                                       2));
+    }
+
+    @Test
+    public void testNameSearch2() {
+        provider.registerEditor(EDITOR1_ID,
+                                EDITOR1_NAME);
+        provider.registerEditor(EDITOR2_ID,
+                                EDITOR2_NAME);
+        DefaultLoadOptions options = new DefaultLoadOptions();
+        options.setNodeNamePattern("1");
+        provider.loadChildren(root,
+                              options,
+                              children -> {
+                                  assertEquals(children.size(),
+                                               1);
+                              });
+    }
+
+    @Test
+    public void testNameSearch3() {
+        provider.registerEditor(EDITOR1_ID,
+                                EDITOR1_NAME);
+        provider.registerEditor(EDITOR2_ID,
+                                EDITOR2_NAME);
+        DefaultLoadOptions options = new DefaultLoadOptions();
+        options.setNodeNamePattern("2");
+        provider.loadChildren(root,
+                              options,
+                              children -> {
+                                  assertEquals(children.size(),
+                                               1);
+                              });
+    }
+
+    @Test
+    public void testRootNode() {
+        assertEquals(root.getPermissionList().size(),
+                     1);
+        checkDependencies(root);
+    }
+
+    @Test
+    public void testChildrenNodes() {
+        root.expand(children -> {
+            for (PermissionNode child : children) {
+                assertEquals(child.getPermissionList().size(),
+                             3);
+                checkDependencies(child);
+            }
+        });
+    }
+
+    protected void checkDependencies(PermissionNode permissionNode) {
+        for (Permission permission : permissionNode.getPermissionList()) {
+            Collection<Permission> dependencies = permissionNode.getDependencies(permission);
+
+            if (permission.getName().startsWith("perspective.read")) {
+                assertEquals(dependencies.size(),
+                             2);
+            } else {
+                assertNull(dependencies);
+            }
+        }
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3524

This PR adds ```PermissionTreeProvider``` for "registered editors" (i.e. a white-list of editors we want to control access to). 