### PR TITLE
[1.3.x] AF-587: Error when removing last field from a grouping.

### DIFF
--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorView.css
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/LayoutEditorView.css
@@ -86,7 +86,7 @@
     padding-bottom: 100px;
     padding-left: 100px;
     padding-right: 100px;
-    height: 350px;
+    height: 100%;
 
 }
 

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponents.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponents.java
@@ -107,6 +107,7 @@ public class ColumnWithComponents implements Column {
         row.init(createDropCommand(),
                  createRowRemoveCommand(),
                  createComponentRemoveCommand(),
+                 this,
                  currentLayoutTemplateSupplier,
                  Row.ROW_DEFAULT_HEIGHT);
     }

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponents.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/columns/ColumnWithComponents.java
@@ -218,6 +218,10 @@ public class ColumnWithComponents implements Column {
         setColumnWidth(newSize);
     }
 
+    public ParameterizedCommand<Column> getRemoveColumnCommand() {
+        return removeColumnCommand;
+    }
+
     @Override
     public LayoutComponent getLayoutComponent() {
         return null;

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/ContainerView.css
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/container/ContainerView.css
@@ -18,6 +18,7 @@
 
 .container-empty {
     padding: 0px;
+    height:90%;
 }
 
 .resolution {

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
@@ -245,6 +245,7 @@ public class Row {
     public void addColumns(ComponentColumn... _columns) {
         for (ComponentColumn column : _columns) {
             column.setParentId(id);
+            column.setId(idGenerator.createColumnID(id));
             column.setDropCommand(dropCommand());
             columns.add(column);
         }
@@ -297,6 +298,9 @@ public class Row {
     }
 
     ParameterizedCommand<Column> removeColumnCommand() {
+        if(parentColumnWithComponents != null) {
+            return parentColumnWithComponents.getRemoveColumnCommand();
+        }
         return (targetCol) -> {
             removeColumn(targetCol);
         };

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/main/java/org/uberfire/ext/layout/editor/client/components/rows/Row.java
@@ -968,6 +968,10 @@ public class Row {
         view.setupResize();
     }
 
+    public ColumnWithComponents getParentColumnWithComponents() {
+        return parentColumnWithComponents;
+    }
+
     public interface View extends UberElement<Row> {
 
         void addColumn(UberElement<ComponentColumn> view);

--- a/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/FullLayoutTest.java
+++ b/uberfire-extensions/uberfire-layout-editor/uberfire-layout-editor-client/src/test/java/org/uberfire/ext/layout/editor/client/components/FullLayoutTest.java
@@ -108,6 +108,8 @@ public class FullLayoutTest extends AbstractLayoutEditorTest {
 
         ColumnWithComponents columnWithComponents = (ColumnWithComponents) getColumnByIndex(row,
                                                                                             SECOND_COLUMN);
+
+        assertNotNull(columnWithComponents.getRow().getParentColumnWithComponents());
         Column newColumn = getColumnByIndex(columnWithComponents.getRow(),
                                             1);
         newColumn.getLayoutComponent().addProperty("c",


### PR DESCRIPTION
Copy of https://github.com/AppFormer/uberfire/pull/860

This also includes a fix that's present on master but not on 1.3.x branch. Without that fix my changes doesn't work.

@ederign could you review?