### PR TITLE
[7.3.x] GUVNOR-3200: [Guided Decision Table] Access control to prohibit business users from modifying columns

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/acl/ACLSettingsTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/test/java/org/uberfire/ext/security/management/client/widgets/management/editor/acl/ACLSettingsTest.java
@@ -35,6 +35,7 @@ import org.uberfire.security.impl.authz.DefaultPermissionManager;
 import org.uberfire.security.impl.authz.DefaultPermissionTypeRegistry;
 
 import static org.mockito.Mockito.*;
+import static org.uberfire.security.impl.authz.DefaultAuthorizationEntry.DEFAULT_PRIORITY;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ACLSettingsTest {
@@ -69,7 +70,7 @@ public class ACLSettingsTest {
 
         permissionManager.setAuthorizationPolicy(permissionManager.newAuthorizationPolicy()
                                                          .role("admin").home("HomeAdmin").priority(10)
-                                                         .group("group1").home("HomeGroup1").priority(0)
+                                                         .group("group1").home("HomeGroup1").priority(DEFAULT_PRIORITY)
                                                          .build()
         );
 
@@ -87,7 +88,7 @@ public class ACLSettingsTest {
         when(homePerspectiveDropDown.getItemName("HomeAdmin")).thenReturn("HomeAdmin");
         when(homePerspectiveDropDown.getItemName("HomeGroup1")).thenReturn("HomeGroup1");
         when(priorityDropDown.getPriorityName(10)).thenReturn("High");
-        when(priorityDropDown.getPriorityName(0)).thenReturn("Normal");
+        when(priorityDropDown.getPriorityName(DEFAULT_PRIORITY)).thenReturn("Very Low");
     }
 
     @Test
@@ -125,7 +126,7 @@ public class ACLSettingsTest {
         verify(view).setPrioritySelector(any());
         verify(view).setHomePerspectiveName("HomeGroup1");
         verify(view).setHomePerspectiveTitle("HomeGroup1");
-        verify(view).setPriorityName("Normal");
+        verify(view).setPriorityName("Very Low");
     }
 
     @Test
@@ -137,7 +138,7 @@ public class ACLSettingsTest {
         verify(view).setHomePerspectiveSelector(any());
         verify(view).setPrioritySelector(any());
         verify(homePerspectiveDropDown).setSelectedPerspective("HomeGroup1");
-        verify(priorityDropDown).setSelectedPriority(0);
+        verify(priorityDropDown).setSelectedPriority(DEFAULT_PRIORITY);
     }
 
     @Test
@@ -161,7 +162,7 @@ public class ACLSettingsTest {
         verify(view).setPrioritySelector(any());
         verify(view).setHomePerspectiveName("DefaultPerspective");
         verify(view).setHomePerspectiveTitle("DefaultPerspective");
-        verify(view).setPriorityName("Normal");
+        verify(view).setPriorityName("Very Low");
     }
 
     @Test

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/DefaultAuthorizationEntry.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/DefaultAuthorizationEntry.java
@@ -23,10 +23,11 @@ import org.uberfire.security.authz.PermissionCollection;
 @Portable
 public class DefaultAuthorizationEntry {
 
+    public static final int DEFAULT_PRIORITY = -100;
     private String description = null;
     private Role role = null;
     private Group group = null;
-    private int priority = 0;
+    private int priority = DEFAULT_PRIORITY;
     private String homePerspective = null;
     private PermissionCollection permissions = new DefaultPermissionCollection();
 

--- a/uberfire-security/uberfire-security-api/src/test/java/org/uberfire/security/impl/authz/DefaultPermissionManagerTest.java
+++ b/uberfire-security/uberfire-security-api/src/test/java/org/uberfire/security/impl/authz/DefaultPermissionManagerTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.security.impl.authz;
+
+import java.util.HashSet;
+
+import org.jboss.errai.security.shared.api.Group;
+import org.jboss.errai.security.shared.api.GroupImpl;
+import org.jboss.errai.security.shared.api.Role;
+import org.jboss.errai.security.shared.api.RoleImpl;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.jboss.errai.security.shared.api.identity.UserImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.security.authz.AuthorizationResult;
+import org.uberfire.security.authz.Permission;
+import org.uberfire.security.authz.PermissionCollection;
+import org.uberfire.security.authz.VotingStrategy;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultPermissionManagerTest {
+
+    private static final String PERMISSION_NAME = "guideddecisiontable.edit.columns";
+
+    private DefaultAuthorizationPolicy authorizationPolicy;
+
+    private DefaultPermissionManager defaultPermissionManager;
+
+    @Before
+    public void setUp() {
+        defaultPermissionManager = spy(new DefaultPermissionManager());
+        authorizationPolicy = spy(new DefaultAuthorizationPolicy());
+
+        defaultPermissionManager.setAuthorizationPolicy(authorizationPolicy);
+    }
+
+    @Test
+    public void testResolvePermissionsPriority() {
+
+        final VotingStrategy priority = VotingStrategy.PRIORITY;
+        final User user = makeUser("director", new RoleImpl("business-user"));
+
+        mockAuthorizationPolicy(user);
+
+        final PermissionCollection resolvedPermission = defaultPermissionManager.resolvePermissions(user, priority);
+        final Permission permission = resolvedPermission.get(PERMISSION_NAME);
+
+        assertEquals(AuthorizationResult.ACCESS_DENIED, permission.getResult());
+    }
+
+    private void mockAuthorizationPolicy(final User user) {
+        mockDefaultPermissions(authorizationPolicy);
+        mockRolePermissions(authorizationPolicy, user);
+        mockGroupPermissions(authorizationPolicy, user);
+    }
+
+    private void mockGroupPermissions(final DefaultAuthorizationPolicy authorizationPolicy,
+                                      final User user) {
+
+        final Group group = user.getGroups().iterator().next();
+        final DefaultAuthorizationEntry groupAuthorizationEntry = new DefaultAuthorizationEntry() {{
+            setGroup(group);
+            // Simulating a priority with the default value
+        }};
+
+        authorizationPolicy.registerAuthzEntry(groupAuthorizationEntry);
+
+        doReturn(makeGrantedPermission()).when(authorizationPolicy).getPermissions(group);
+    }
+
+    private void mockRolePermissions(final DefaultAuthorizationPolicy authorizationPolicy,
+                                     final User user) {
+
+        final Role role = user.getRoles().iterator().next();
+        final DefaultAuthorizationEntry roleAuthorizationEntry = new DefaultAuthorizationEntry() {{
+            setRole(role);
+
+            // Simulating a priority set by the user
+            setPriority(0);
+        }};
+
+        authorizationPolicy.registerAuthzEntry(roleAuthorizationEntry);
+
+        doReturn(makeDeniedPermissionCollection()).when(authorizationPolicy).getPermissions(role);
+    }
+
+    private void mockDefaultPermissions(final DefaultAuthorizationPolicy authorizationPolicy) {
+        doReturn(makeGrantedPermission()).when(authorizationPolicy).getPermissions();
+    }
+
+    private UserImpl makeUser(final String name,
+                              final Role role) {
+
+        final HashSet<Role> roles = new HashSet<Role>() {{
+            add(role);
+        }};
+        final HashSet<Group> groups = new HashSet<Group>() {{
+            // Users have a group with their names by default
+            add(new GroupImpl(name));
+        }};
+
+        return new UserImpl(name, roles, groups);
+    }
+
+    private DefaultPermissionCollection makeDeniedPermissionCollection() {
+        return new DefaultPermissionCollection() {{
+            add(makePermissionDenied());
+        }};
+    }
+
+    private DefaultPermissionCollection makeGrantedPermission() {
+        return new DefaultPermissionCollection() {{
+            add(makePermissionGranted());
+        }};
+    }
+
+    private DotNamedPermission makePermissionDenied() {
+        return new DotNamedPermission(PERMISSION_NAME, false);
+    }
+
+    private DotNamedPermission makePermissionGranted() {
+        return new DotNamedPermission(PERMISSION_NAME, true);
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-3200

---

Cherry-picked from https://github.com/AppFormer/uberfire/pull/861

---

Part of an ensemble:
- https://github.com/AppFormer/uberfire/pull/863
- https://github.com/kiegroup/kie-docs/pull/407
- https://github.com/kiegroup/kie-wb-distributions/pull/634
- https://github.com/kiegroup/drools-wb/pull/644
- https://github.com/kiegroup/kie-wb-common/pull/1222