### PR TITLE
AF-634: fix for SSH issue not propagating to the rest of the cluster.

### DIFF
--- a/uberfire-io/pom.xml
+++ b/uberfire-io/pom.xml
@@ -45,6 +45,10 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-jgit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-nio2-api</artifactId>
     </dependency>
     <dependency>
@@ -66,11 +70,6 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-nio2-jgit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/uberfire-io/src/main/java/org/uberfire/io/impl/cluster/helix/ClusterServiceHelix.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/impl/cluster/helix/ClusterServiceHelix.java
@@ -16,6 +16,7 @@
 
 package org.uberfire.io.impl.cluster.helix;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,6 +41,9 @@ import org.uberfire.commons.message.AsyncCallback;
 import org.uberfire.commons.message.MessageHandlerResolver;
 import org.uberfire.commons.message.MessageType;
 import org.uberfire.io.impl.cluster.ClusterMessageType;
+import org.uberfire.java.nio.file.api.FileSystemProviders;
+import org.uberfire.java.nio.file.spi.FileSystemProvider;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider;
 
 import static java.util.Arrays.*;
 import static java.util.UUID.*;
@@ -70,6 +74,10 @@ public class ClusterServiceHelix implements ClusterService {
         this.participantManager = getZkHelixManager( clusterName, zkAddress, instanceName );
         PriorityDisposableRegistry.register( this );
         start();
+        final FileSystemProvider provider = FileSystemProviders.resolveProvider(URI.create("git://test"));
+        if (provider != null && provider instanceof JGitFileSystemProvider){
+            ((JGitFileSystemProvider) provider).setupClusterService(this);
+        }
     }
 
     HelixManager getZkHelixManager( String clusterName,


### PR DESCRIPTION
Now the clusterService injection to JGitFileSystemProvider is simplified
(in the end we never managed to isolate cluster per repository anyway).