### PR TITLE
[2.0.x] AF-434: [HTML editor] Font size, Font color and Backgroud color are not working. (fixes typo)

### DIFF
--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/htmleditor/HtmlEditorView.html
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/htmleditor/HtmlEditorView.html
@@ -86,7 +86,7 @@
                         <li>
                             <a href="javascript:;" class="wysiwyg-font-size-xx-large"
                                data-wysihtml-command="fontSizeStyle" data-wysihtml-command-value="xx-large" unselectable="on"
-                               data-field="font-size-action-xx-large" data-i18n-key="xx-small"></a>
+                               data-field="font-size-action-xx-large" data-i18n-key="xx-large"></a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
@jsoltes @ederign this PR fixes a typo... sorry.