### PR TITLE
[BPMSPL-744] GIT related enhancements for scalable workspaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
     <!-- WildFly version used together with the GWT's Super Dev Mode -->
     <version.org.wildfly.gwt.sdm>10.1.0.Final</version.org.wildfly.gwt.sdm>
 
+    <version.org.apache.activemq.artemis>2.3.0</version.org.apache.activemq.artemis>
+    <version.io.netty>4.1.16.Final</version.io.netty>
+    <netty-transport-native-epoll-classifier>linux-x86_64</netty-transport-native-epoll-classifier>
+    <netty-transport-native-kqueue-classifier>osx-x86_64</netty-transport-native-kqueue-classifier>
+
     <!-- Lienzo core upgrade required by Stunner. Can be removed once IP BOM is upgraded.-->
     <version.com.ahome-it.lienzo-core>2.0.292-RELEASE</version.com.ahome-it.lienzo-core>
     <version.com.ahome-it.lienzo-tests>2.0.292-RELEASE</version.com.ahome-it.lienzo-tests>
@@ -937,11 +942,59 @@
         <version>${version.org.jboss.byteman}</version>
         <scope>test</scope>
       </dependency>
-
       <dependency>
         <groupId>org.wildfly.security</groupId>
         <artifactId>wildfly-elytron</artifactId>
         <version>${version.org.wildfly.security}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-internal</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <!-- Apache ActiveMQ/Artemis -->
+      <dependency>
+        <groupId>org.apache.activemq</groupId>
+        <artifactId>artemis-jms-client</artifactId>
+        <version>${version.org.apache.activemq.artemis}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-buffer</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${version.io.netty}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <version>${version.io.netty}</version>
+        <classifier>${netty-transport-native-epoll-classifier}</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-kqueue</artifactId>
+        <version>${version.io.netty}</version>
+        <classifier>${netty-transport-native-kqueue-classifier}</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${version.io.netty}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/uberfire-asset-mgmt/uberfire-asset-mgmt-backend/src/main/java/org/guvnor/asset/management/backend/service/RepositoryStructureServiceImpl.java
+++ b/uberfire-asset-mgmt/uberfire-asset-mgmt-backend/src/main/java/org/guvnor/asset/management/backend/service/RepositoryStructureServiceImpl.java
@@ -190,7 +190,7 @@ public class RepositoryStructureServiceImpl
                 return null;
             }
 
-            ioService.startBatch(new FileSystem[]{Paths.convert(path).getFileSystem()},
+            ioService.startBatch(Paths.convert(path).getFileSystem(),
                                  optionsFactory.makeCommentedOption(comment != null ? comment : ""));
 
             boolean saveParentPom = false;

--- a/uberfire-backend/uberfire-backend-cdi/pom.xml
+++ b/uberfire-backend/uberfire-backend-cdi/pom.xml
@@ -113,6 +113,12 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-nio2-jgit</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/SystemConfigProducer.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/SystemConfigProducer.java
@@ -65,6 +65,7 @@ import org.uberfire.java.nio.file.FileStore;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.FileSystemAlreadyExistsException;
 import org.uberfire.java.nio.file.InvalidPathException;
+import org.uberfire.java.nio.file.LockableFileSystem;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.PathMatcher;
 import org.uberfire.java.nio.file.PatternSyntaxException;
@@ -83,13 +84,7 @@ public class SystemConfigProducer implements Extension {
 
     private final List<OrderedBean> startupEagerBeans = new LinkedList<OrderedBean>();
     private final List<OrderedBean> startupBootstrapBeans = new LinkedList<OrderedBean>();
-    private final Comparator<OrderedBean> priorityComparator = new Comparator<OrderedBean>() {
-        @Override
-        public int compare(final OrderedBean o1,
-                           final OrderedBean o2) {
-            return o1.priority - o2.priority;
-        }
-    };
+    private final Comparator<OrderedBean> priorityComparator = (o1, o2) -> o1.priority - o2.priority;
     private boolean systemFSNotExists = true;
     private boolean ioStrategyBeanNotFound = true;
 
@@ -242,6 +237,7 @@ public class SystemConfigProducer implements Extension {
             public Set<Type> getTypes() {
                 return new HashSet<Type>() {{
                     add(FileSystem.class);
+                    add(LockableFileSystem.class);
                     add(Object.class);
                 }};
             }
@@ -573,6 +569,11 @@ public class SystemConfigProducer implements Extension {
         }
 
         @Override
+        public String getName() {
+            return "DummyFileSystem";
+        }
+
+        @Override
         public void close() throws IOException {
 
         }
@@ -592,14 +593,6 @@ public class SystemConfigProducer implements Extension {
                             final int priority) {
             this.bean = bean;
             this.priority = priority;
-        }
-    }
-
-    private class DummyStarable implements Startable {
-
-        @Override
-        public void start() {
-
         }
     }
 

--- a/uberfire-backend/uberfire-backend-server/pom.xml
+++ b/uberfire-backend/uberfire-backend-server/pom.xml
@@ -138,6 +138,12 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-nio2-jgit</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/IOWatchServiceNonDotImpl.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/IOWatchServiceNonDotImpl.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 import org.uberfire.backend.server.io.watch.AbstractIOWatchService;
 import org.uberfire.commons.concurrent.Unmanaged;
 import org.uberfire.java.nio.base.WatchContext;
+import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.StandardWatchEventKind;
 import org.uberfire.java.nio.file.WatchEvent;
 import org.uberfire.workbench.events.ResourceAddedEvent;
@@ -58,22 +59,26 @@ public class IOWatchServiceNonDotImpl extends AbstractIOWatchService {
     public boolean doFilter(WatchEvent<?> object) {
         final WatchContext context = (WatchContext) object.context();
         if (object.kind().equals(StandardWatchEventKind.ENTRY_MODIFY)) {
-            if (context.getOldPath().getFileName().toString().startsWith(".")) {
+            if (shouldFilter(context.getOldPath())) {
                 return true;
             }
         } else if (object.kind().equals(StandardWatchEventKind.ENTRY_CREATE)) {
-            if (context.getPath().getFileName().toString().startsWith(".")) {
+            if (shouldFilter(context.getPath())) {
                 return true;
             }
         } else if (object.kind().equals(StandardWatchEventKind.ENTRY_RENAME)) {
-            if (context.getOldPath().getFileName().toString().startsWith(".")) {
+            if (shouldFilter(context.getOldPath())) {
                 return true;
             }
         } else if (object.kind().equals(StandardWatchEventKind.ENTRY_DELETE)) {
-            if (context.getOldPath().getFileName().toString().startsWith(".")) {
+            if (shouldFilter(context.getOldPath())) {
                 return true;
             }
         }
         return false;
+    }
+
+    boolean shouldFilter(Path path) {
+        return path != null && path.getFileName() != null && path.getFileName().toString().startsWith(".");
     }
 }

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/cluster/ClusterServiceFactorySimpleImpl.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/cluster/ClusterServiceFactorySimpleImpl.java
@@ -21,9 +21,6 @@ import org.uberfire.commons.cluster.ClusterServiceFactory;
 import org.uberfire.commons.message.MessageHandlerResolver;
 import org.uberfire.io.impl.cluster.helix.ClusterServiceHelix;
 
-/**
- * TODO: update me
- */
 public class ClusterServiceFactorySimpleImpl implements ClusterServiceFactory {
 
     private final String clusterName;

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/io/watch/AbstractIOWatchService.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/io/watch/AbstractIOWatchService.java
@@ -35,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.backend.server.util.Filter;
 import org.uberfire.commons.async.DescriptiveRunnable;
-import org.uberfire.commons.concurrent.Managed;
 import org.uberfire.commons.concurrent.Unmanaged;
 import org.uberfire.commons.services.cdi.ApplicationStarted;
 import org.uberfire.io.IOWatchService;
@@ -57,12 +56,12 @@ public abstract class AbstractIOWatchService implements IOWatchService,
     private static final Integer AWAIT_TERMINATION_TIMEOUT = Integer.parseInt(System.getProperty("org.uberfire.watcher.quitetimeout",
                                                                                                  "3"));
 
-    private final List<FileSystem> fileSystems = new ArrayList<FileSystem>();
-    private final List<WatchService> watchServices = new ArrayList<WatchService>();
+    private final List<String> fileSystems = new ArrayList<>();
+    private final List<WatchService> watchServices = new ArrayList<>();
     protected boolean isDisposed = false;
 
     private boolean started;
-    private final Set<AsyncWatchService> watchThreads = new HashSet<AsyncWatchService>();
+    private final Set<AsyncWatchService> watchThreads = new HashSet<>();
     private Event<ResourceBatchChangesEvent> resourceBatchChanges;
     private Event<ResourceUpdatedEvent> resourceUpdatedEvent;
     private Event<ResourceRenamedEvent> resourceRenamedEvent;
@@ -72,7 +71,7 @@ public abstract class AbstractIOWatchService implements IOWatchService,
 
     private IOWatchServiceExecutor executor = null;
 
-    private final Set<Future<?>> jobs = new CopyOnWriteArraySet<Future<?>>();
+    private final Set<Future<?>> jobs = new CopyOnWriteArraySet<>();
 
     public AbstractIOWatchService() {
     }
@@ -156,13 +155,13 @@ public abstract class AbstractIOWatchService implements IOWatchService,
 
     @Override
     public boolean hasWatchService(final FileSystem fs) {
-        return fileSystems.contains(fs);
+        return fileSystems.contains(fs.getName());
     }
 
     @Override
     public void addWatchService(final FileSystem fs,
                                 final WatchService ws) {
-        fileSystems.add(fs);
+        fileSystems.add(fs.getName());
         watchServices.add(ws);
 
         final AsyncWatchService asyncWatchService = new AsyncWatchService() {

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/io/watch/IOWatchServiceExecutorImpl.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/io/watch/IOWatchServiceExecutorImpl.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.ejb.AccessTimeout;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 import javax.ejb.TransactionAttribute;
@@ -57,9 +58,8 @@ import static org.uberfire.backend.server.util.Paths.convert;
 @Singleton
 @Startup
 @TransactionAttribute(NOT_SUPPORTED)
+@AccessTimeout(value = 30, unit = java.util.concurrent.TimeUnit.SECONDS)
 public class IOWatchServiceExecutorImpl implements IOWatchServiceExecutor {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(IOWatchServiceExecutorImpl.class);
 
     @Inject
     private Event<ResourceBatchChangesEvent> resourceBatchChanges;
@@ -95,7 +95,7 @@ public class IOWatchServiceExecutorImpl implements IOWatchServiceExecutor {
         WatchContext firstContext = null;
 
         if (events.size() > 1) {
-            final Map<Path, Collection<ResourceChange>> changes = new HashMap<Path, Collection<ResourceChange>>();
+            final Map<Path, Collection<ResourceChange>> changes = new HashMap<>();
             for (final WatchEvent event : events) {
                 if (!filter.doFilter(event)) {
                     if (firstContext == null) {
@@ -105,7 +105,7 @@ public class IOWatchServiceExecutorImpl implements IOWatchServiceExecutor {
                     if (result != null) {
                         if (!changes.containsKey(result.getK1())) {
                             changes.put(result.getK1(),
-                                        new ArrayList<ResourceChange>());
+                                        new ArrayList<>());
                         }
                         changes.get(result.getK1()).add(result.getK2());
                     }

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/FileSystemResourceAdaptor.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/FileSystemResourceAdaptor.java
@@ -17,8 +17,7 @@
 package org.uberfire.backend.server.security;
 
 import org.uberfire.backend.authz.FileSystemResourceType;
-import org.uberfire.java.nio.base.FileSystemId;
-import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 import org.uberfire.security.ResourceType;
 import org.uberfire.security.authz.RuntimeContentResource;
 
@@ -26,26 +25,25 @@ public class FileSystemResourceAdaptor implements RuntimeContentResource {
 
     public static final FileSystemResourceType RESOURCE_TYPE = new FileSystemResourceType();
 
-    private final FileSystem fileSystem;
+    private final String identifier;
+    private FileSystemMetadata fileSystemMetadata;
 
-    public FileSystemResourceAdaptor(final FileSystem fileSystem) {
-        if (fileSystem == null) {
-            this.fileSystem = null;
+    public FileSystemResourceAdaptor(final FileSystemMetadata fsFileSystemMetadata) {
+        this.fileSystemMetadata = fsFileSystemMetadata;
+        if (fsFileSystemMetadata.isAFileSystemID()) {
+            identifier = fsFileSystemMetadata.getId();
         } else {
-            this.fileSystem = fileSystem.getRootDirectories().iterator().next().getFileSystem();
+            identifier = fsFileSystemMetadata.getUri();
         }
-    }
-
-    public FileSystem getFileSystem() {
-        return fileSystem;
     }
 
     @Override
     public String getIdentifier() {
-        if (fileSystem instanceof FileSystemId) {
-            return ((FileSystemId) fileSystem).id();
-        }
-        return fileSystem.toString();
+        return identifier;
+    }
+
+    FileSystemMetadata getFileSystemMetadata() {
+        return fileSystemMetadata;
     }
 
     @Override

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/IOServiceSecuritySetup.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/IOServiceSecuritySetup.java
@@ -27,6 +27,7 @@ import org.jboss.errai.security.shared.service.AuthenticationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.commons.services.cdi.Startup;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 import org.uberfire.java.nio.file.api.FileSystemProviders;
 import org.uberfire.java.nio.file.spi.FileSystemProvider;
 import org.uberfire.java.nio.security.FileSystemUser;
@@ -90,7 +91,7 @@ public class IOServiceSecuritySetup {
                 );
                 sfp.setAuthorizer((fs, fileSystemUser) ->
                                           authorizationManager.authorize(
-                                                  new FileSystemResourceAdaptor(fs),
+                                                  new FileSystemResourceAdaptor(new FileSystemMetadata(fs)),
                                                   ((UserAdapter) fileSystemUser).getWrappedUser())
 
                 );

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/util/Paths.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/util/Paths.java
@@ -30,7 +30,7 @@ import static org.uberfire.backend.vfs.PathFactory.newPath;
 
 public final class Paths {
 
-    private static Map<org.uberfire.java.nio.file.FileSystem, FileSystem> cache = new HashMap<org.uberfire.java.nio.file.FileSystem, FileSystem>();
+    private static Map<org.uberfire.java.nio.file.FileSystem, FileSystem> cache = new HashMap<>();
 
     public static Path convert(final org.uberfire.java.nio.file.Path path) {
         if (path == null) {
@@ -64,7 +64,7 @@ public final class Paths {
 
     public static FileSystem convert(final org.uberfire.java.nio.file.FileSystem fs) {
         if (!cache.containsKey(fs)) {
-            final Map<String, String> roots = new HashMap<String, String>();
+            final Map<String, String> roots = new HashMap<>();
             for (final org.uberfire.java.nio.file.Path root : fs.getRootDirectories()) {
                 roots.put(root.toUri().toString(),
                           root.getFileName() == null ? "/" : root.getFileName().toString());

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/IOWatchServiceNonDotImplTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/IOWatchServiceNonDotImplTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.backend.server;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.java.nio.file.Path;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IOWatchServiceNonDotImplTest {
+
+    @Test
+    public void shouldFilterTest() {
+        Path path = mock(Path.class);
+
+        IOWatchServiceNonDotImpl io = new IOWatchServiceNonDotImpl();
+
+        assertFalse(io.shouldFilter(null));
+
+        when(path.getFileName()).thenReturn(null);
+        assertFalse(io.shouldFilter(path));
+
+        Path filename = mock(Path.class);
+        when(filename.toString()).thenReturn("dont_start_with_.");
+        when(path.getFileName()).thenReturn(filename);
+        assertFalse(io.shouldFilter(path));
+
+        when(filename.toString()).thenReturn(".dora");
+        assertTrue(io.shouldFilter(path));
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/io/JGitFileSystemLazyCacheTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/io/JGitFileSystemLazyCacheTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.backend.server.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProxy;
+import org.uberfire.mocks.FileSystemTestingUtils;
+
+import static org.junit.Assert.*;
+
+public class JGitFileSystemLazyCacheTest {
+
+    private static FileSystemTestingUtils fsUtils = new FileSystemTestingUtils();
+
+    static {
+        System.out.println("Working Dir: " + new File("").getAbsoluteFile().getAbsolutePath());
+    }
+
+    @Before
+    public void setup() throws IOException {
+        System.setProperty("org.uberfire.nio.jgit.cache.instances",
+                           "2");
+        fsUtils.setup(false);
+    }
+
+    @After
+    public void cleanupFileSystem() {
+        fsUtils.cleanup();
+        System.clearProperty("org.uberfire.nio.jgit.cache.instances");
+    }
+
+    @Test
+    public void basicCache() throws IOException {
+        String repoName = "amend-repo-test";
+        Path firstWrite = fsUtils.getIoService().get(URI.create("git://" + repoName + "/init1.file"));
+
+        String content = "dora!";
+
+        Path secondWrite = fsUtils.getIoService().get(URI.create("git://" + repoName + "/init2.file"));
+
+        fsUtils.getIoService().write(firstWrite,
+                                     content);
+
+        String jgitcontent = fsUtils.getIoService().readAllString(firstWrite);
+        assertEquals(content,
+                     jgitcontent);
+
+        fsUtils.getIoService().write(secondWrite,
+                                     content);
+        JGitFileSystemProxy fileSystem = (JGitFileSystemProxy) firstWrite.getFileSystem();
+        JGitFileSystemProxy fileSystem1 = (JGitFileSystemProxy) secondWrite.getFileSystem();
+        assertEquals(fileSystem,
+                     fileSystem1);
+    }
+
+    @Test
+    public void regenerateFSCache() throws IOException {
+        String defaultRepo = "git://amend-repo-test";
+
+        Path firstWriteFS1 = fsUtils.getIoService().get(URI.create(defaultRepo + "/init1.file"));
+
+        FileSystem fileSystem1Instance1 = firstWriteFS1.getFileSystem();
+
+        String dora1 = "dora1";
+        String dora2 = "dora2";
+        fsUtils.getIoService().write(firstWriteFS1,
+                                     dora1);
+
+        fsUtils.setupJGitRepository(defaultRepo + "2",
+                                    false);
+        Path writeFS2 = fsUtils.getIoService().get(URI.create(defaultRepo + "2" + "/init1.file"));
+        fsUtils.getIoService().write(writeFS2,
+                                     dora1);
+
+        fsUtils.setupJGitRepository(defaultRepo + "3",
+                                    false);
+        Path writeFS3 = fsUtils.getIoService().get(URI.create(defaultRepo + "3" + "/init1.file"));
+        fsUtils.getIoService().write(writeFS3,
+                                     dora1);
+
+        //memoized cache size == 2 , so
+
+        fsUtils.setupJGitRepository(defaultRepo,
+                                    false);
+        Path secondWriteFS1 = fsUtils.getIoService().get(URI.create(defaultRepo + "/init2.file"));
+        fsUtils.getIoService().write(secondWriteFS1,
+                                     dora2);
+
+        FileSystem fileSystem1Instance2 = secondWriteFS1.getFileSystem();
+
+        //not equals because we have to regenerate, but still represent the same FS
+        assertTrue(System.identityHashCode(fileSystem1Instance1) != System.identityHashCode(fileSystem1Instance2));
+        assertTrue(fileSystem1Instance1.hashCode() == fileSystem1Instance2.hashCode());
+        assertEquals(fileSystem1Instance1,
+                     fileSystem1Instance2);
+
+        //let's remove fs1 again from cache
+        fsUtils.setupJGitRepository(defaultRepo + "5",
+                                    false);
+        fsUtils.setupJGitRepository(defaultRepo + "6",
+                                    false);
+
+        //read to see if all the writes are fine on fs1
+
+        String actual1 = fsUtils.getIoService().readAllString(fsUtils.getIoService().get(URI.create(defaultRepo + "/init1.file")));
+        String actual2 = fsUtils.getIoService().readAllString(fsUtils.getIoService().get(URI.create(defaultRepo + "/init2.file")));
+
+        assertEquals(dora1,
+                     actual1);
+        assertEquals(dora2,
+                     actual2);
+    }
+
+    @Test
+    public void branchingTest() throws IOException {
+
+        FileSystem fileSystem = fsUtils.setupJGitRepository("git://dora-repo",
+                                                            true);
+        fsUtils.getProvider().forceAsDefault();
+
+        Path branchPath = fileSystem.getPath("branch",
+                                             "dir");
+
+        Path pathOnBranch = branchPath.resolve("test.file");
+
+        String expected = "dora";
+        fsUtils.getIoService().write(pathOnBranch,
+                                     expected);
+
+        String actual = fsUtils.getIoService().readAllString(branchPath.resolve("test.file"));
+
+        assertEquals(expected,
+                     actual);
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/io/watch/AbstractIOWatchServiceTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/io/watch/AbstractIOWatchServiceTest.java
@@ -23,10 +23,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.backend.server.util.Filter;
 import org.uberfire.commons.async.DescriptiveThreadFactory;
 import org.uberfire.java.nio.IOException;
 import org.uberfire.java.nio.file.ClosedWatchServiceException;
+import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.InterruptedException;
 import org.uberfire.java.nio.file.WatchEvent;
 import org.uberfire.java.nio.file.WatchKey;
@@ -34,7 +37,9 @@ import org.uberfire.java.nio.file.WatchService;
 import org.uberfire.java.nio.file.Watchable;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 
+@RunWith(MockitoJUnitRunner.class)
 public class AbstractIOWatchServiceTest {
 
     @Test
@@ -110,7 +115,7 @@ public class AbstractIOWatchServiceTest {
                 }
             };
 
-            service.addWatchService(null,
+            service.addWatchService(mock(FileSystem.class),
                                     ws);
 
             Set<AsyncWatchService> watchThreads = null;
@@ -123,13 +128,8 @@ public class AbstractIOWatchServiceTest {
             }
             AsyncWatchService asyncWatchService = watchThreads.iterator().next();
 
-            IOWatchServiceExecutor wsExecutor = new IOWatchServiceExecutor() {
-
-                @Override
-                public void execute(WatchKey watchKey,
-                                    Filter<WatchEvent<?>> filter) {
-                    throw new RuntimeException("dummy");
-                }
+            IOWatchServiceExecutor wsExecutor = (watchKey, filter) -> {
+                throw new RuntimeException("dummy");
             };
 
             try {

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/FileSystemResourceAdaptorTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/FileSystemResourceAdaptorTest.java
@@ -22,14 +22,12 @@ import java.util.Arrays;
 import org.junit.Test;
 import org.uberfire.java.nio.base.FileSystemId;
 import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 import org.uberfire.java.nio.file.Path;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-/**
- * TODO: update me
- */
 public class FileSystemResourceAdaptorTest {
 
     @Test
@@ -49,9 +47,10 @@ public class FileSystemResourceAdaptorTest {
         when(((FileSystemId) mockedFSId).id()).thenReturn("my-fsid");
 
         {
-            final FileSystemResourceAdaptor fileSystemResourceAdaptor = new FileSystemResourceAdaptor(mockedFS);
-            assertEquals(mockedFSId,
-                         fileSystemResourceAdaptor.getFileSystem());
+            FileSystemMetadata fileSystemInfo = new FileSystemMetadata(mockedFSId);
+            final FileSystemResourceAdaptor fileSystemResourceAdaptor = new FileSystemResourceAdaptor(fileSystemInfo);
+            assertEquals(fileSystemInfo,
+                         fileSystemResourceAdaptor.getFileSystemMetadata());
             assertEquals("my-fsid",
                          fileSystemResourceAdaptor.getIdentifier());
         }

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/IOServiceSecuritySetupTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/IOServiceSecuritySetupTest.java
@@ -16,6 +16,7 @@
 
 package org.uberfire.backend.server.security;
 
+import java.net.URI;
 import java.util.Arrays;
 import javax.enterprise.inject.Instance;
 
@@ -92,8 +93,10 @@ public class IOServiceSecuritySetupTest {
                                            withSettings().extraInterfaces(FileSystemId.class));
         when(((FileSystemId) mockedFSId).id()).thenReturn("mockFS");
         final Path rootPath = mock(Path.class);
+        when(rootPath.toUri()).thenReturn(URI.create("/"));
         when(mockfs.getRootDirectories()).thenReturn(Arrays.asList(rootPath));
         when(mockedFSId.getRootDirectories()).thenReturn(Arrays.asList(rootPath));
+
         when(rootPath.getFileSystem()).thenReturn(mockedFSId);
 
         assertTrue(mockFsp.authorizer.authorize(mockfs,
@@ -132,6 +135,7 @@ public class IOServiceSecuritySetupTest {
         final FileSystem mockedFSId = mock(FileSystem.class,
                                            withSettings().extraInterfaces(FileSystemId.class));
         final Path rootPath = mock(Path.class);
+        when(rootPath.toUri()).thenReturn(URI.create("/"));
         when(mockfs.getRootDirectories()).thenReturn(Arrays.asList(rootPath));
         when(mockedFSId.getRootDirectories()).thenReturn(Arrays.asList(rootPath));
         when(rootPath.getFileSystem()).thenReturn(mockedFSId);

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/MockSecuredFilesystemProvider.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/MockSecuredFilesystemProvider.java
@@ -396,5 +396,10 @@ public class MockSecuredFilesystemProvider implements SecuredFileSystemProvider 
         public WatchService newWatchService() throws UnsupportedOperationException, IOException {
             return null;
         }
+
+        @Override
+        public String getName() {
+            return "name";
+        }
     }
 }

--- a/uberfire-extensions/uberfire-apps/uberfire-apps-backend/src/main/java/org/uberfire/ext/apps/impl/AppsPersistenceImpl.java
+++ b/uberfire-extensions/uberfire-apps/uberfire-apps-backend/src/main/java/org/uberfire/ext/apps/impl/AppsPersistenceImpl.java
@@ -63,7 +63,7 @@ public class AppsPersistenceImpl implements AppsPersistenceAPI {
     @PostConstruct
     public void setup() {
         try {
-            fileSystem = ioService.newFileSystem(URI.create("default://plugins"),
+            fileSystem = ioService.newFileSystem(URI.create("default://system_ou/plugins"),
                                                  new HashMap<String, Object>() {{
                                                      put("init",
                                                          Boolean.TRUE);
@@ -71,7 +71,7 @@ public class AppsPersistenceImpl implements AppsPersistenceAPI {
                                                          Boolean.TRUE);
                                                  }});
         } catch (final FileSystemAlreadyExistsException e) {
-            fileSystem = ioService.getFileSystem(URI.create("default://plugins"));
+            fileSystem = ioService.getFileSystem(URI.create("default://system_ou/plugins"));
         }
         this.root = fileSystem.getRootDirectories().iterator().next();
     }
@@ -87,7 +87,7 @@ public class AppsPersistenceImpl implements AppsPersistenceAPI {
     }
 
     private Map<String, List<String>> generateTagMap() {
-        Map<String, List<String>> tagsMap = new HashMap<String, List<String>>();
+        Map<String, List<String>> tagsMap = new HashMap<>();
         final Collection<LayoutEditorModel> layoutEditorModels = pluginServices.listLayoutEditor(PluginType.PERSPECTIVE_LAYOUT);
         for (LayoutEditorModel layoutEditorModel : layoutEditorModels) {
             LayoutTemplate layoutTemplate = layoutServices.convertLayoutFromString(layoutEditorModel.getLayoutEditorModel());
@@ -96,7 +96,7 @@ public class AppsPersistenceImpl implements AppsPersistenceAPI {
                 for (String tag : tags) {
                     List<String> perspectives = tagsMap.get(tag.toUpperCase());
                     if (perspectives == null) {
-                        perspectives = new ArrayList<String>();
+                        perspectives = new ArrayList<>();
                     }
                     perspectives.add(layoutTemplate.getName());
                     tagsMap.put(tag.toUpperCase(),

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/version/MockIOService.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/version/MockIOService.java
@@ -37,6 +37,7 @@ import org.uberfire.java.nio.file.DirectoryStream;
 import org.uberfire.java.nio.file.FileAlreadyExistsException;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.FileSystemAlreadyExistsException;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 import org.uberfire.java.nio.file.FileSystemNotFoundException;
 import org.uberfire.java.nio.file.InterruptedException;
 import org.uberfire.java.nio.file.NoSuchFileException;
@@ -71,19 +72,8 @@ public class MockIOService
     }
 
     @Override
-    public void startBatch(FileSystem[] fileSystems,
-                           Option... options) throws InterruptedException {
-
-    }
-
-    @Override
     public void startBatch(FileSystem fileSystem,
                            Option... options) throws InterruptedException {
-
-    }
-
-    @Override
-    public void startBatch(FileSystem... fileSystems) throws InterruptedException {
 
     }
 
@@ -109,7 +99,7 @@ public class MockIOService
     }
 
     @Override
-    public Iterable<FileSystem> getFileSystems() {
+    public Iterable<FileSystemMetadata> getFileSystemMetadata() {
         return null;
     }
 

--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-commons-io/src/main/java/org/uberfire/ext/metadata/io/IOServiceIndexedImpl.java
@@ -66,7 +66,7 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
     private final BatchIndex batchIndex;
 
     private final Class<? extends FileAttributeView>[] views;
-    private final List<FileSystem> watchedList = new ArrayList<FileSystem>();
+    private final List<String> watchedList = new ArrayList<>();
     private final List<WatchService> watchServices = new ArrayList<WatchService>();
 
     private final Observer observer;
@@ -200,20 +200,10 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
     public FileSystem getFileSystem(final URI uri)
             throws IllegalArgumentException, FileSystemNotFoundException,
             ProviderNotFoundException, SecurityException {
-        try {
-            final FileSystem fs = super.getFileSystem(uri);
-            indexIfFresh(fs);
-            setupWatchService(fs);
-            return fs;
-        } catch (final IllegalArgumentException ex) {
-            throw ex;
-        } catch (final FileSystemNotFoundException ex) {
-            throw ex;
-        } catch (final ProviderNotFoundException ex) {
-            throw ex;
-        } catch (final SecurityException ex) {
-            throw ex;
-        }
+        final FileSystem fs = super.getFileSystem(uri);
+        indexIfFresh(fs);
+        setupWatchService(fs);
+        return fs;
     }
 
     @Override
@@ -221,23 +211,11 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
                                     final Map<String, ?> env)
             throws IllegalArgumentException, FileSystemAlreadyExistsException,
             ProviderNotFoundException, IOException, SecurityException {
-        try {
-            final FileSystem fs = super.newFileSystem(uri,
-                                                      env);
-            index(fs);
-            setupWatchService(fs);
-            return fs;
-        } catch (final IllegalArgumentException ex) {
-            throw ex;
-        } catch (final FileSystemAlreadyExistsException ex) {
-            throw ex;
-        } catch (final ProviderNotFoundException ex) {
-            throw ex;
-        } catch (final IOException ex) {
-            throw ex;
-        } catch (final SecurityException ex) {
-            throw ex;
-        }
+        final FileSystem fs = super.newFileSystem(uri,
+                                                  env);
+        index(fs);
+        setupWatchService(fs);
+        return fs;
     }
 
     @Override
@@ -254,11 +232,11 @@ public class IOServiceIndexedImpl extends IOServiceDotFileImpl {
     }
 
     protected void setupWatchService(final FileSystem fs) {
-        if (watchedList.contains(fs)) {
+        if (watchedList.contains(fs.getName())) {
             return;
         }
         final WatchService ws = fs.newWatchService();
-        watchedList.add(fs);
+        watchedList.add(fs.getName());
         watchServices.add(ws);
 
         final ExecutorService defaultInstance = this.executorService;

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/src/main/java/org/uberfire/ext/plugin/backend/PluginMediaServlet.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/src/main/java/org/uberfire/ext/plugin/backend/PluginMediaServlet.java
@@ -78,7 +78,7 @@ public class PluginMediaServlet
             }
         }
         try {
-            fileSystem = ioService.newFileSystem(URI.create("default://plugins"),
+            fileSystem = ioService.newFileSystem(URI.create("default://system_ou/plugins"),
                                                  new HashMap<String, Object>() {{
                                                      put("init",
                                                          Boolean.TRUE);
@@ -86,7 +86,7 @@ public class PluginMediaServlet
                                                          Boolean.TRUE);
                                                  }});
         } catch (final FileSystemAlreadyExistsException e) {
-            fileSystem = ioService.getFileSystem(URI.create("default://plugins"));
+            fileSystem = ioService.getFileSystem(URI.create("default://system_ou/plugins"));
         }
         this.root = fileSystem.getRootDirectories().iterator().next();
     }
@@ -170,7 +170,7 @@ public class PluginMediaServlet
                 }
 
                 try {
-                    ioService.startBatch();
+                    ioService.startBatch(path.getFileSystem());
                     writeFile(ioService,
                               path,
                               fileItem);

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/src/main/java/org/uberfire/ext/plugin/backend/PluginServicesImpl.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-backend/src/main/java/org/uberfire/ext/plugin/backend/PluginServicesImpl.java
@@ -28,7 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -79,10 +78,10 @@ import org.uberfire.java.nio.file.StandardDeleteOption;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
 import org.uberfire.rpc.SessionInfo;
 
-import static org.uberfire.backend.server.util.Paths.convert;
 import static org.kie.soup.commons.validation.PortablePreconditions.checkCondition;
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotEmpty;
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
+import static org.uberfire.backend.server.util.Paths.convert;
 import static org.uberfire.java.nio.file.Files.walkFileTree;
 
 @Service
@@ -122,7 +121,7 @@ public class PluginServicesImpl implements PluginServices {
     public void init() {
         this.gson = new GsonBuilder().setPrettyPrinting().create();
         try {
-            fileSystem = getIoService().newFileSystem(URI.create("default://plugins"),
+            fileSystem = getIoService().newFileSystem(URI.create("default://system_ou/plugins"),
                                                       new HashMap<String, Object>() {{
                                                           put("init",
                                                               Boolean.TRUE);
@@ -130,8 +129,9 @@ public class PluginServicesImpl implements PluginServices {
                                                               Boolean.TRUE);
                                                       }});
         } catch (FileSystemAlreadyExistsException e) {
-            fileSystem = getIoService().getFileSystem(URI.create("default://plugins"));
+            fileSystem = getIoService().getFileSystem(URI.create("default://system_ou/plugins"));
         }
+
         this.root = fileSystem.getRootDirectories().iterator().next();
     }
 
@@ -223,7 +223,7 @@ public class PluginServicesImpl implements PluginServices {
 
     @Override
     public Collection<Plugin> listPlugins() {
-        final Collection<Plugin> result = new ArrayList<Plugin>();
+        final Collection<Plugin> result = new ArrayList<>();
 
         if (getIoService().exists(root)) {
             walkFileTree(checkNotNull("root",

--- a/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/code/CodeElement.java
+++ b/uberfire-extensions/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/code/CodeElement.java
@@ -22,9 +22,6 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.uberfire.ext.plugin.model.CodeType;
 import org.uberfire.mvp.ParameterizedCommand;
 
-/**
- * TODO: update me
- */
 public interface CodeElement {
 
     void addNav(final DropDownMenu parent,

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/io/IOServiceSecuritySetupTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/io/IOServiceSecuritySetupTest.java
@@ -16,6 +16,7 @@
 
 package org.uberfire.ext.security.server.io;
 
+import java.net.URI;
 import java.util.Arrays;
 
 import org.jboss.errai.security.shared.api.identity.User;
@@ -44,6 +45,7 @@ public class IOServiceSecuritySetupTest {
 
         when(fs.getRootDirectories()).thenReturn(Arrays.asList(rootPath));
         when(rootPath.getFileSystem()).thenReturn(fs);
+        when(rootPath.toUri()).thenReturn(URI.create("/"));
 
         final IOSecurityService service = new IOSecurityService(new MockIOService(),
                                                                 new MockAuthenticationService(),
@@ -54,6 +56,7 @@ public class IOServiceSecuritySetupTest {
         try {
             service.startBatch(fs);
         } catch (Exception e) {
+            e.printStackTrace();
             fail("error");
         }
     }
@@ -62,6 +65,7 @@ public class IOServiceSecuritySetupTest {
     public void secureExecuted() {
         final FileSystem fs = mock(FileSystem.class);
         final Path rootPath = mock(Path.class);
+        when(rootPath.toUri()).thenReturn(URI.create("/"));
 
         when(fs.getRootDirectories()).thenReturn(Arrays.asList(rootPath));
         when(rootPath.getFileSystem()).thenReturn(fs);

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/io/MockIOService.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/io/MockIOService.java
@@ -37,6 +37,7 @@ import org.uberfire.java.nio.file.DirectoryStream;
 import org.uberfire.java.nio.file.FileAlreadyExistsException;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.FileSystemAlreadyExistsException;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 import org.uberfire.java.nio.file.FileSystemNotFoundException;
 import org.uberfire.java.nio.file.NoSuchFileException;
 import org.uberfire.java.nio.file.NotDirectoryException;
@@ -48,9 +49,6 @@ import org.uberfire.java.nio.file.attribute.FileAttribute;
 import org.uberfire.java.nio.file.attribute.FileAttributeView;
 import org.uberfire.java.nio.file.attribute.FileTime;
 
-/**
- * TODO: update me
- */
 public class MockIOService implements IOService {
 
     @Override
@@ -64,19 +62,8 @@ public class MockIOService implements IOService {
     }
 
     @Override
-    public void startBatch(FileSystem[] fs,
-                           Option... options) {
-
-    }
-
-    @Override
     public void startBatch(FileSystem fs,
                            Option... options) {
-
-    }
-
-    @Override
-    public void startBatch(FileSystem... fs) {
 
     }
 
@@ -102,7 +89,7 @@ public class MockIOService implements IOService {
     }
 
     @Override
-    public Iterable<FileSystem> getFileSystems() {
+    public Iterable<FileSystemMetadata> getFileSystemMetadata() {
         return null;
     }
 

--- a/uberfire-extensions/uberfire-social-activities/uberfire-social-activities-backend/src/test/java/org/ext/uberfire/social/activities/persistence/IOServiceUnitTestWrapper.java
+++ b/uberfire-extensions/uberfire-social-activities/uberfire-social-activities-backend/src/test/java/org/ext/uberfire/social/activities/persistence/IOServiceUnitTestWrapper.java
@@ -37,6 +37,7 @@ import org.uberfire.java.nio.file.DirectoryStream;
 import org.uberfire.java.nio.file.FileAlreadyExistsException;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.FileSystemAlreadyExistsException;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 import org.uberfire.java.nio.file.FileSystemNotFoundException;
 import org.uberfire.java.nio.file.NoSuchFileException;
 import org.uberfire.java.nio.file.NotDirectoryException;
@@ -52,7 +53,7 @@ import static org.mockito.Mockito.*;
 
 public class IOServiceUnitTestWrapper implements IOService {
 
-    Map<String, String> fileSystem = new HashMap<String, String>();
+    Map<String, String> fileSystem = new HashMap<>();
 
     @Override
     public void dispose() {
@@ -65,19 +66,8 @@ public class IOServiceUnitTestWrapper implements IOService {
     }
 
     @Override
-    public void startBatch(FileSystem[] fs,
-                           Option... options) {
-
-    }
-
-    @Override
     public void startBatch(FileSystem fs,
                            Option... options) {
-
-    }
-
-    @Override
-    public void startBatch(FileSystem... fs) {
 
     }
 
@@ -105,7 +95,7 @@ public class IOServiceUnitTestWrapper implements IOService {
     }
 
     @Override
-    public Iterable<FileSystem> getFileSystems() {
+    public Iterable<FileSystemMetadata> getFileSystemMetadata() {
         return null;
     }
 

--- a/uberfire-io/src/main/java/org/uberfire/io/IOService.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/IOService.java
@@ -38,6 +38,7 @@ import org.uberfire.java.nio.file.DirectoryStream;
 import org.uberfire.java.nio.file.FileAlreadyExistsException;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.FileSystemAlreadyExistsException;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 import org.uberfire.java.nio.file.FileSystemNotFoundException;
 import org.uberfire.java.nio.file.NoSuchFileException;
 import org.uberfire.java.nio.file.NotDirectoryException;
@@ -58,13 +59,8 @@ public interface IOService extends PriorityDisposable {
 
     void startBatch(final FileSystem fs);
 
-    void startBatch(final FileSystem[] fs,
-                    final Option... options);
-
     void startBatch(final FileSystem fs,
                     final Option... options);
-
-    void startBatch(final FileSystem... fs);
 
     void endBatch();
 
@@ -77,7 +73,7 @@ public interface IOService extends PriorityDisposable {
     Path get(final URI uri)
             throws IllegalArgumentException, FileSystemNotFoundException, SecurityException;
 
-    Iterable<FileSystem> getFileSystems();
+    Iterable<FileSystemMetadata> getFileSystemMetadata();
 
     FileSystem getFileSystem(final URI uri)
             throws IllegalArgumentException, FileSystemNotFoundException,

--- a/uberfire-io/src/main/java/org/uberfire/io/impl/cluster/FileSystemSyncLock.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/impl/cluster/FileSystemSyncLock.java
@@ -21,8 +21,7 @@ import java.util.Map;
 
 import org.uberfire.commons.cluster.LockExecuteNotifyAsyncReleaseTemplate;
 import org.uberfire.commons.message.MessageType;
-import org.uberfire.java.nio.base.FileSystemId;
-import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 
 import static org.uberfire.io.impl.cluster.ClusterMessageType.SYNC_FS;
 
@@ -34,12 +33,11 @@ public class FileSystemSyncLock<V> extends LockExecuteNotifyAsyncReleaseTemplate
     private final String uri;
 
     public FileSystemSyncLock(final String serviceId,
-                              final FileSystem _fileSystem) {
-        final FileSystem fileSystem = _fileSystem.getRootDirectories().iterator().next().getFileSystem();
+                              final FileSystemMetadata fileSystemMetadata) {
         this.serviceId = serviceId;
-        this.scheme = fileSystem.getRootDirectories().iterator().next().toUri().getScheme();
-        this.id = ((FileSystemId) fileSystem).id();
-        this.uri = fileSystem.toString();
+        this.scheme = fileSystemMetadata.getScheme();
+        this.id = fileSystemMetadata.getId();
+        this.uri = fileSystemMetadata.getUri();
     }
 
     @Override

--- a/uberfire-io/src/main/java/org/uberfire/io/impl/cluster/FileSystemSyncNonLock.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/impl/cluster/FileSystemSyncNonLock.java
@@ -23,8 +23,7 @@ import java.util.concurrent.RunnableFuture;
 
 import org.uberfire.commons.cluster.ClusterService;
 import org.uberfire.commons.message.MessageType;
-import org.uberfire.java.nio.base.FileSystemId;
-import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 
 import static org.uberfire.io.impl.cluster.ClusterMessageType.SYNC_FS;
 
@@ -36,12 +35,12 @@ public class FileSystemSyncNonLock<V> {
     private final String uri;
 
     public FileSystemSyncNonLock(final String serviceId,
-                                 final FileSystem _fileSystem) {
-        final FileSystem fileSystem = _fileSystem.getRootDirectories().iterator().next().getFileSystem();
+                                 final FileSystemMetadata fsInfo) {
         this.serviceId = serviceId;
-        this.scheme = fileSystem.getRootDirectories().iterator().next().toUri().getScheme();
-        this.id = ((FileSystemId) fileSystem).id();
-        this.uri = fileSystem.toString();
+
+        this.scheme = fsInfo.getScheme();
+        this.id = fsInfo.getId();
+        this.uri = fsInfo.getUri();
     }
 
     public MessageType getMessageType() {

--- a/uberfire-io/src/main/java/org/uberfire/io/lock/BatchLockControl.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/lock/BatchLockControl.java
@@ -19,17 +19,61 @@ package org.uberfire.io.lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.LockableFileSystem;
 
 public class BatchLockControl {
 
     private ReentrantLock lock = new ReentrantLock(true);
+    private FileSystem fileSystemOnBatch;
 
-    public void lock(final FileSystem... fileSystems) {
+    public void lock(final FileSystem fs) {
         lock.lock();
+        try{
+            makeSureThatIsOnlyOneFSOnCurrentBatch(fs);
+        }
+        catch (BatchRuntimeException e){
+            lock.unlock();
+            throw e;
+        }
+
+        if (!isAlreadyOnBatch(fs)) {
+            if (isLockable(fs)) {
+                fileSystemOnBatch = fs;
+                ((LockableFileSystem) fs).lock();
+            } else {
+                throw new BatchRuntimeException("Not a LockableFileSystem : "
+                                                        + fileSystemOnBatch.toString());
+            }
+        }
+    }
+
+    private void makeSureThatIsOnlyOneFSOnCurrentBatch(FileSystem fs) {
+        if (fileSystemOnBatch != null && !fileSystemOnBatch.equals(fs)) {
+            throw new BatchRuntimeException("We already have a batch process running on another FS : "
+                                                    + fileSystemOnBatch.toString());
+        }
+    }
+
+    private boolean isAlreadyOnBatch(FileSystem fileSystem) {
+        return fileSystemOnBatch != null && fileSystemOnBatch.equals(fileSystem);
     }
 
     public void unlock() {
-        lock.unlock();
+        if (lock.isLocked()) {
+            if (shouldUnlockLockedFileSystems()) {
+                ((LockableFileSystem) fileSystemOnBatch).unlock();
+                fileSystemOnBatch = null;
+            }
+            lock.unlock();
+        }
+    }
+
+    private boolean shouldUnlockLockedFileSystems() {
+        return lock.getHoldCount() == 1 && fileSystemOnBatch != null && isLockable(fileSystemOnBatch);
+    }
+
+    private boolean isLockable(FileSystem fileSystem) {
+        return fileSystem instanceof LockableFileSystem;
     }
 
     public boolean isLocked() {
@@ -38,5 +82,16 @@ public class BatchLockControl {
 
     public int getHoldCount() {
         return lock.getHoldCount();
+    }
+
+    public FileSystem getFileSystemOnBatch() {
+        return fileSystemOnBatch;
+    }
+
+    public class BatchRuntimeException extends RuntimeException {
+
+        public BatchRuntimeException(String message) {
+            super(message);
+        }
     }
 }

--- a/uberfire-io/src/test/java/org/uberfire/io/GitIOServiceDotFileTest.java
+++ b/uberfire-io/src/test/java/org/uberfire/io/GitIOServiceDotFileTest.java
@@ -26,7 +26,7 @@ import java.util.Random;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.attribute.FileAttribute;
 
@@ -94,17 +94,17 @@ public class GitIOServiceDotFileTest extends CommonIOExceptionsServiceDotFileTes
 
         final URI newRepo = URI.create("git://" + new Date().getTime() + "-repo-test");
         ioService().newFileSystem(newRepo,
-                                  new HashMap<String, Object>());
+                                  new HashMap<>());
 
         final URI newRepo2 = URI.create("git://" + new Date().getTime() + "-repo2-test");
         ioService().newFileSystem(newRepo2,
-                                  new HashMap<String, Object>());
+                                  new HashMap<>());
 
         final URI newRepo3 = URI.create("git://" + new Date().getTime() + "-repo3-test");
         ioService().newFileSystem(newRepo3,
-                                  new HashMap<String, Object>());
+                                  new HashMap<>());
 
-        final Iterator<FileSystem> iterator = ioService.getFileSystems().iterator();
+        final Iterator<FileSystemMetadata> iterator = ioService.getFileSystemMetadata().iterator();
 
         assertNotNull(iterator);
 
@@ -212,7 +212,7 @@ public class GitIOServiceDotFileTest extends CommonIOExceptionsServiceDotFileTes
 
             try {
                 ioService().newFileSystem(newRepo,
-                                          new HashMap<String, Object>());
+                                          new HashMap<>());
             } catch (final Exception ex) {
             } finally {
                 created = true;

--- a/uberfire-io/src/test/java/org/uberfire/io/attribute/DotFileAttrViewTest.java
+++ b/uberfire-io/src/test/java/org/uberfire/io/attribute/DotFileAttrViewTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.*;
  */
 public class DotFileAttrViewTest {
 
-    protected static final List<File> tempFiles = new ArrayList<File>();
+    protected static final List<File> tempFiles = new ArrayList<>();
     protected static IOService ioService = null;
     private static boolean created = false;
 
@@ -79,9 +79,9 @@ public class DotFileAttrViewTest {
 
     @Test
     public void testDotFileAttrAccess() throws IOException {
-        final URI newRepo = URI.create("git://" + new Date().getTime() + "-repo-test");
+        final URI newRepo = URI.create("git://" + new Date().getTime() + "-repo-test-3");
         ioService().newFileSystem(newRepo,
-                                  new HashMap<String, Object>());
+                                  new HashMap<>());
 
         final Path dir = ioService().get(newRepo);
         final Path file = dir.resolve("myFile.txt");
@@ -194,7 +194,7 @@ public class DotFileAttrViewTest {
                                path);
             System.out.println(".niogit: " + path);
 
-            final URI newRepo = URI.create("git://repo-test");
+            final URI newRepo = URI.create("git://repo-test-3");
 
             try {
                 ioService().newFileSystem(newRepo,

--- a/uberfire-io/src/test/java/org/uberfire/io/impl/WatcherTest.java
+++ b/uberfire-io/src/test/java/org/uberfire/io/impl/WatcherTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.io.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.uberfire.commons.lifecycle.PriorityDisposableRegistry;
+import org.uberfire.io.CommonIOServiceDotFileTest;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.StandardWatchEventKind;
+import org.uberfire.java.nio.file.WatchEvent;
+import org.uberfire.java.nio.file.WatchService;
+import org.uberfire.java.nio.file.api.FileSystemProviders;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemImpl;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProxy;
+
+import static org.junit.Assert.*;
+
+public class WatcherTest {
+
+    final static IOService ioService = new IOServiceDotFileImpl();
+
+    private static File path = null;
+    static FileSystem fs1;
+    static JGitFileSystemImpl jgitFs1;
+
+    @BeforeClass
+    public static void setup() throws IOException {
+        assertTrue(PriorityDisposableRegistry.getDisposables().contains(ioService));
+        path = CommonIOServiceDotFileTest.createTempDirectory();
+
+        System.setProperty("org.uberfire.nio.git.dir",
+                           path.getAbsolutePath());
+
+        final URI newRepo = URI.create("git://amend-repo-test");
+
+        fs1 = ioService.newFileSystem(newRepo,
+                                      new HashMap<>());
+        jgitFs1 = (JGitFileSystemImpl) ((JGitFileSystemProxy) fs1).getRealJGitFileSystem();
+        Path init = ioService.get(URI.create("git://amend-repo-test/init.file"));
+        ioService.write(init,
+                        "setupFS!");
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        FileUtils.deleteQuietly(path);
+        JGitFileSystemProvider gitFsProvider = (JGitFileSystemProvider) FileSystemProviders.resolveProvider(URI.create("git://whatever"));
+        gitFsProvider.shutdown();
+        FileUtils.deleteQuietly(gitFsProvider.getGitRepoContainerDir());
+        System.clearProperty("org.uberfire.nio.git.dir");
+    }
+
+    @Test
+    public void simpleWatcherTest() {
+
+        final Path init = ioService.get(URI.create("git://amend-repo-test/dora1.txt"));
+        final WatchService ws = init.getFileSystem().newWatchService();
+
+        ioService.write(init,
+                        "init!");
+
+        {
+            List<WatchEvent<?>> events = ws.poll().pollEvents();
+            WatchEvent.Kind<?> kind = events.get(0).kind();
+            assertEquals(kind.name(),
+                         StandardWatchEventKind.ENTRY_CREATE.name());
+            assertEquals(1,
+                         events.size());
+        }
+        ioService.write(init,
+                        "init 2!");
+        {
+            List<WatchEvent<?>> events = ws.poll().pollEvents();
+            WatchEvent.Kind<?> kind = events.get(0).kind();
+            assertEquals(kind.name(),
+                         StandardWatchEventKind.ENTRY_MODIFY.name());
+            assertEquals(1,
+                         events.size());
+        }
+    }
+}

--- a/uberfire-io/src/test/java/org/uberfire/io/impl/cluster/FileSystemSyncTest.java
+++ b/uberfire-io/src/test/java/org/uberfire/io/impl/cluster/FileSystemSyncTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.uberfire.java.nio.base.FileSystemId;
 import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 import org.uberfire.java.nio.file.Path;
 
 import static org.junit.Assert.*;
@@ -38,6 +39,7 @@ public class FileSystemSyncTest {
 
         final Path rootPath = mock(Path.class);
 
+
         when(mockedFS.getRootDirectories()).thenReturn(Arrays.asList(rootPath));
         when(mockedFSId.getRootDirectories()).thenReturn(Arrays.asList(rootPath));
 
@@ -48,7 +50,7 @@ public class FileSystemSyncTest {
 
         {
             final FileSystemSyncLock<String> fileSystemSyncLock = new FileSystemSyncLock<String>("serviceId",
-                                                                                                 mockedFS);
+                                                                                                 new FileSystemMetadata(mockedFSId));
             final Map<String, String> content = fileSystemSyncLock.buildContent();
 
             assertEquals("my-fsid",
@@ -56,7 +58,7 @@ public class FileSystemSyncTest {
         }
         {
             final FileSystemSyncNonLock<String> fileSystemSyncNonLock = new FileSystemSyncNonLock<String>("serviceId",
-                                                                                                          mockedFS);
+                                                                                                          new FileSystemMetadata(mockedFSId));
             final Map<String, String> content = fileSystemSyncNonLock.buildContent();
 
             assertEquals("my-fsid",

--- a/uberfire-io/src/test/java/org/uberfire/io/impl/cluster/IOServiceClusterImplTest.java
+++ b/uberfire-io/src/test/java/org/uberfire/io/impl/cluster/IOServiceClusterImplTest.java
@@ -18,6 +18,7 @@ package org.uberfire.io.impl.cluster;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 import org.uberfire.commons.cluster.ClusterService;
@@ -25,6 +26,7 @@ import org.uberfire.io.impl.IOServiceLockable;
 import org.uberfire.io.lock.BatchLockControl;
 import org.uberfire.java.nio.base.FileSystemId;
 import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 import org.uberfire.java.nio.file.Option;
 import org.uberfire.java.nio.file.Path;
 
@@ -53,8 +55,9 @@ public class IOServiceClusterImplTest {
         final IOServiceLockable serviceLockable = mock(IOServiceLockable.class);
         final BatchLockControl batchLockControl = mock(BatchLockControl.class);
 
-        when(serviceLockable.getFileSystems()).thenReturn(Arrays.asList(mockedFSId,
-                                                                        mockedFS));
+        List<FileSystemMetadata> fsInfo = Arrays.asList(new FileSystemMetadata(mockedFSId),
+                                                        new FileSystemMetadata(mockedFS));
+        when(serviceLockable.getFileSystemMetadata()).thenReturn(fsInfo);
         when(batchLockControl.getHoldCount()).thenReturn(0);
         when(serviceLockable.getLockControl()).thenReturn(batchLockControl);
 
@@ -91,7 +94,7 @@ public class IOServiceClusterImplTest {
             assertEquals(0,
                          ioServiceCluster.batchFileSystems.size());
 
-            ioServiceCluster.startBatch(new FileSystem[]{mockedFS},
+            ioServiceCluster.startBatch(mockedFS,
                                         mock(Option.class));
 
             assertEquals(1,

--- a/uberfire-io/src/test/java/org/uberfire/io/regex/AntPathMatcherTest.java
+++ b/uberfire-io/src/test/java/org/uberfire/io/regex/AntPathMatcherTest.java
@@ -66,7 +66,6 @@ public class AntPathMatcherTest {
         JGitFileSystemProvider gitFsProvider = (JGitFileSystemProvider) FileSystemProviders.resolveProvider(URI.create("git://whatever"));
         gitFsProvider.shutdown();
         FileUtils.deleteQuietly(gitFsProvider.getGitRepoContainerDir());
-        gitFsProvider.rescanForExistingRepositories();
     }
 
     @Test

--- a/uberfire-nio2-backport/uberfire-nio2-api/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-api/pom.xml
@@ -47,14 +47,13 @@
     </dependency>
 
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-nio2-fs</artifactId>
-      <scope>test</scope>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-nio2-jgit</artifactId>
+      <artifactId>uberfire-nio2-fs</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileSystemProvidersTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileSystemProvidersTest.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import org.junit.Test;
 import org.uberfire.java.nio.file.api.FileSystemProviders;
 import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
-import org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -29,17 +28,11 @@ public class FileSystemProvidersTest {
 
     @Test
     public void generalTests() {
-        assertThat(FileSystemProviders.installedProviders()).isNotNull().isNotEmpty().hasSize(2);
+        assertThat(FileSystemProviders.installedProviders()).isNotNull().isNotEmpty().hasSize(1);
         assertThat(FileSystemProviders.getDefaultProvider()).isNotNull().isInstanceOf(SimpleFileSystemProvider.class);
 
         assertThat(FileSystemProviders.resolveProvider(URI.create("default:///"))).isNotNull().isInstanceOf(SimpleFileSystemProvider.class);
         assertThat(FileSystemProviders.resolveProvider(URI.create("file:///"))).isNotNull().isInstanceOf(SimpleFileSystemProvider.class);
-        assertThat(FileSystemProviders.resolveProvider(URI.create("git:///"))).isNotNull().isInstanceOf(JGitFileSystemProvider.class);
-    }
-
-    @Test(expected = FileSystemNotFoundException.class)
-    public void resolveNonExistentProvider() {
-        assertThat(FileSystemProviders.resolveProvider(URI.create("nothing:///"))).isNotNull().isInstanceOf(JGitFileSystemProvider.class);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileSystemsTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FileSystemsTest.java
@@ -16,31 +16,16 @@
 
 package org.uberfire.java.nio.file;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.uberfire.java.nio.fs.file.BaseSimpleFileSystem;
-import org.uberfire.java.nio.fs.jgit.JGitFileSystem;
-import org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider;
-import org.uberfire.java.nio.fs.jgit.JGitPathImpl;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
 public class FileSystemsTest {
-
-    @Before
-    @After
-    public void cleanup() throws IOException {
-        FileUtils.deleteDirectory(new File(JGitFileSystemProvider.REPOSITORIES_CONTAINER_DIR));
-    }
 
     @Test
     public void testGetDefault() {
@@ -51,45 +36,6 @@ public class FileSystemsTest {
     public void testGetFileSystemByURI() {
         assertThat(FileSystems.getFileSystem(URI.create("default:///"))).isNotNull().isInstanceOf(BaseSimpleFileSystem.class);
         assertThat(FileSystems.getFileSystem(URI.create("file:///"))).isNotNull().isInstanceOf(BaseSimpleFileSystem.class);
-    }
-
-    @Test
-    public void testNewFileSystem() {
-
-        final Map<String, Object> env = new HashMap<String, Object>(2);
-        env.put("userName",
-                "user");
-        env.put("password",
-                "pass");
-
-        final FileSystem fs = FileSystems.newFileSystem(URI.create("git://my-test"),
-                                                        env);
-
-        assertThat(fs).isNotNull();
-
-        final FileSystem newFS = FileSystems.newFileSystem(JGitPathImpl.create((JGitFileSystem) fs,
-                                                                               "new_test",
-                                                                               "my-other-test",
-                                                                               false),
-                                                           null);
-
-        assertThat(newFS).isNotNull();
-    }
-
-    @Test(expected = FileSystemAlreadyExistsException.class)
-    public void testNewOnExistingFileSystem() {
-
-        final Map<String, Object> env = new HashMap<String, Object>(2);
-        env.put("userName",
-                "user");
-        env.put("password",
-                "pass");
-
-        FileSystems.newFileSystem(URI.create("git://test"),
-                                  env);
-
-        FileSystems.newFileSystem(URI.create("git://test"),
-                                  env);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FilesTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FilesTest.java
@@ -20,9 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 
 import org.junit.Test;
 import org.uberfire.java.nio.base.BasicFileAttributesImpl;
@@ -30,8 +28,6 @@ import org.uberfire.java.nio.base.NotImplementedException;
 import org.uberfire.java.nio.channels.SeekableByteChannel;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributeView;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
-import org.uberfire.java.nio.fs.file.BaseSimpleFileStore;
-import org.uberfire.java.nio.fs.jgit.JGitFileStore;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Assertions.fail;
@@ -475,21 +471,6 @@ public class FilesTest extends AbstractBaseTest {
         }
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void copyDifferentProviders() {
-        final Map<String, Object> env = new HashMap<String, Object>(2);
-        env.put("userName",
-                "user");
-        env.put("password",
-                "pass");
-        final URI uri = URI.create("git://test" + System.currentTimeMillis());
-        FileSystems.newFileSystem(uri,
-                                  env);
-
-        Files.copy(Paths.get(uri),
-                   newTempDir());
-    }
-
     @Test(expected = IllegalArgumentException.class)
     public void copyNull1() throws IOException {
         Files.copy(newTempDir(),
@@ -595,40 +576,6 @@ public class FilesTest extends AbstractBaseTest {
     public void moveNull3() throws IOException {
         Files.move(null,
                    null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void moveDifferentProviders() {
-        final Map<String, Object> env = new HashMap<String, Object>(2);
-        env.put("userName",
-                "user");
-        env.put("password",
-                "pass");
-        FileSystems.newFileSystem(URI.create("git://testXXXXXXX"),
-                                  env);
-
-        Files.move(Paths.get(URI.create("git://testXXXXXXX")),
-                   newTempDir());
-    }
-
-    @Test
-    public void getFileStore() {
-        assertThat(Files.getFileStore(Paths.get("/some/file"))).isNotNull().isInstanceOf(BaseSimpleFileStore.class);
-
-        final Map<String, Object> env = new HashMap<String, Object>(2);
-        env.put("userName",
-                "user");
-        env.put("password",
-                "pass");
-        final String repoName = "git://testXXXXXXX" + System.currentTimeMillis();
-        final URI uri = URI.create(repoName);
-        FileSystems.newFileSystem(uri,
-                                  env);
-
-        assertThat(Files.getFileStore(Paths.get(uri))).isNotNull().isInstanceOf(JGitFileStore.class);
-
-        final URI fetch = URI.create(repoName + "?fetch");
-        FileSystems.getFileSystem(fetch);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -15,4 +15,3 @@
 #
 
 org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
-org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/main/java/org/uberfire/java/nio/fs/file/BaseSimpleFileSystem.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/main/java/org/uberfire/java/nio/fs/file/BaseSimpleFileSystem.java
@@ -44,6 +44,7 @@ public abstract class BaseSimpleFileSystem implements FileSystem,
     private final String defaultDirectory;
     private final Set<String> supportedFileAttributeViews;
     private final File[] roots;
+    private final String name;
 
     BaseSimpleFileSystem(final FileSystemProvider provider,
                          final String path) {
@@ -59,6 +60,7 @@ public abstract class BaseSimpleFileSystem implements FileSystem,
                      roots);
         checkCondition("should have at least one root",
                        roots.length > 0);
+        this.name = path != null ? path : id();
         this.roots = roots;
         this.provider = provider;
         this.defaultDirectory = validateDefaultDir(path);
@@ -176,5 +178,10 @@ public abstract class BaseSimpleFileSystem implements FileSystem,
     @Override
     public String toString() {
         return "file://" + id();
+    }
+
+    @Override
+    public String getName() {
+        return name;
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/pom.xml
@@ -31,6 +31,7 @@
   <description>UberFire NIO.2 :: JGIT Impl</description>
 
   <dependencies>
+
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-commons</artifactId>
@@ -44,6 +45,11 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-nio2-model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-api</artifactId>
     </dependency>
 
     <dependency>
@@ -85,6 +91,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
@@ -111,7 +122,54 @@
       <artifactId>byteman-bmunit</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-jms-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.geronimo.specs</groupId>
+          <artifactId>geronimo-jms_2.0_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.jms</groupId>
+      <artifactId>jboss-jms-api_2.0_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <classifier>${netty-transport-native-epoll-classifier}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <classifier>${netty-transport-native-kqueue-classifier}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystem.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystem.java
@@ -16,48 +16,20 @@
 
 package org.uberfire.java.nio.fs.jgit;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.Queue;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.transport.CredentialsProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.uberfire.java.nio.IOException;
 import org.uberfire.java.nio.base.FileSystemId;
-import org.uberfire.java.nio.base.FileSystemState;
 import org.uberfire.java.nio.base.FileSystemStateAware;
 import org.uberfire.java.nio.base.options.CommentedOption;
-import org.uberfire.java.nio.file.ClosedWatchServiceException;
-import org.uberfire.java.nio.file.FileStore;
 import org.uberfire.java.nio.file.FileSystem;
-import org.uberfire.java.nio.file.InterruptedException;
-import org.uberfire.java.nio.file.InvalidPathException;
+import org.uberfire.java.nio.file.LockableFileSystem;
 import org.uberfire.java.nio.file.Path;
-import org.uberfire.java.nio.file.PathMatcher;
-import org.uberfire.java.nio.file.PatternSyntaxException;
 import org.uberfire.java.nio.file.WatchEvent;
-import org.uberfire.java.nio.file.WatchKey;
-import org.uberfire.java.nio.file.WatchService;
-import org.uberfire.java.nio.file.Watchable;
-import org.uberfire.java.nio.file.attribute.UserPrincipalLookupService;
-import org.uberfire.java.nio.file.spi.FileSystemProvider;
 import org.uberfire.java.nio.fs.jgit.util.Git;
 import org.uberfire.java.nio.fs.jgit.util.model.CommitInfo;
+
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableSet;
@@ -65,529 +37,54 @@ import static org.eclipse.jgit.lib.Repository.shortenRefName;
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotEmpty;
 import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
 
-public class JGitFileSystem implements FileSystem,
-                                       FileSystemId,
-                                       FileSystemStateAware {
+public interface JGitFileSystem extends FileSystem,
+                                        FileSystemId,
+                                        FileSystemStateAware,
+                                        LockableFileSystem { 
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(JGitFileSystem.class);
+    Git getGit();
 
-    private static final Set<String> SUPPORTED_ATTR_VIEWS = unmodifiableSet(new HashSet<String>(asList("basic",
-                                                                                                       "version")));
+    CredentialsProvider getCredential();
 
-    private final JGitFileSystemProvider provider;
-    private final Git git;
-    private final String toStringContent;
-    private boolean isClosed = false;
-    private final FileStore fileStore;
-    private final String name;
-    private final CredentialsProvider credential;
-    private final Map<WatchService, Queue<WatchKey>> events = new ConcurrentHashMap<WatchService, Queue<WatchKey>>();
-    private final Collection<WatchService> watchServices = new ArrayList<WatchService>();
-    private final AtomicInteger numberOfCommitsSinceLastGC = new AtomicInteger(0);
+    void checkClosed() throws IllegalStateException;
 
-    private FileSystemState state = FileSystemState.NORMAL;
-    private CommitInfo batchCommitInfo = null;
-    private Map<Path, Boolean> hadCommitOnBatchState = new ConcurrentHashMap<Path, Boolean>();
+    void publishEvents(Path watchable,
+                       List<WatchEvent<?>> elist);
 
-    private final Lock lock = new Lock();
+    boolean isOnBatch();
 
-    JGitFileSystem(final JGitFileSystemProvider provider,
-                   final Map<String, String> fullHostNames,
-                   final Git git,
-                   final String name,
-                   final CredentialsProvider credential) {
-        this.provider = checkNotNull("provider",
-                                     provider);
-        this.git = checkNotNull("git",
-                                git);
-        this.name = checkNotEmpty("name",
-                                  name);
-        this.credential = checkNotNull("credential",
-                                       credential);
-        this.fileStore = new JGitFileStore(this.git.getRepository());
-        if (fullHostNames != null && !fullHostNames.isEmpty()) {
-            final StringBuilder sb = new StringBuilder();
-            final Iterator<Map.Entry<String, String>> iterator = fullHostNames.entrySet().iterator();
-            while (iterator.hasNext()) {
-                final Map.Entry<String, String> entry = iterator.next();
-                sb.append(entry.getKey()).append("://").append(entry.getValue()).append("/").append(name);
-                if (iterator.hasNext()) {
-                    sb.append("\n");
-                }
-            }
-            toStringContent = sb.toString();
-        } else {
-            toStringContent = "git://" + name;
-        }
-    }
+    void setState(String state);
 
-    @Override
-    public String id() {
-        return name;
-    }
+    CommitInfo buildCommitInfo(String defaultMessage,
+                               CommentedOption op);
 
-    public String getName() {
-        return name;
-    }
+    void setBatchCommitInfo(String defaultMessage,
+                            CommentedOption op);
 
-    public Git getGit() {
-        return git;
-    }
+    void setHadCommitOnBatchState(Path path,
+                                  boolean hadCommitOnBatchState);
 
-    public CredentialsProvider getCredential() {
-        return credential;
-    }
+    void setHadCommitOnBatchState(boolean value);
 
-    @Override
-    public FileSystemProvider provider() {
-        return provider;
-    }
+    boolean isHadCommitOnBatchState(Path path);
 
-    @Override
-    public boolean isOpen() {
-        return !isClosed;
-    }
+    void setBatchCommitInfo(CommitInfo batchCommitInfo);
 
-    @Override
-    public boolean isReadOnly() {
-        return false;
-    }
+    CommitInfo getBatchCommitInfo();
 
-    @Override
-    public String getSeparator() {
-        return "/";
-    }
+    int incrementAndGetCommitCount();
 
-    @Override
-    public Iterable<Path> getRootDirectories() {
-        checkClosed();
-        return () -> new Iterator<Path>() {
+    void resetCommitCount();
 
-            Iterator<Ref> branches = null;
+    int getNumberOfCommitsSinceLastGC();
 
-            @Override
-            public boolean hasNext() {
-                if (branches == null) {
-                    init();
-                }
-                return branches.hasNext();
-            }
+    void addOldHeadsOfPendingDiffs(String branchName,
+                                   NotificationModel notificationModel);
 
-            private void init() {
-                branches = git.listRefs().iterator();
-            }
+    Map<String, NotificationModel> getOldHeadsOfPendingDiffs();
 
-            @Override
-            public Path next() {
+    boolean hasOldHeadsOfPendingDiffs();
 
-                if (branches == null) {
-                    init();
-                }
-                try {
-                    return JGitPathImpl.createRoot(JGitFileSystem.this,
-                                                   "/",
-                                                   shortenRefName(branches.next().getName()) + "@" + name,
-                                                   false);
-                } catch (NoSuchElementException e) {
-                    throw new IllegalStateException(
-                            "The gitnio directory is in an invalid state. " +
-                                    "If you are an IntelliJ IDEA user, " +
-                                    "there is a known bug which requires specifying " +
-                                    "a custom directory for your git repository. " +
-                                    "You can specify a custom directory using '-Dorg.uberfire.nio.git.dir=/tmp/dir'. " +
-                                    "For more details please see https://issues.jboss.org/browse/UF-275.",
-                            e);
-                }
-            }
+    void clearOldHeadsOfPendingDiffs();
 
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException();
-            }
-        };
-    }
-
-    @Override
-    public Iterable<FileStore> getFileStores() {
-        checkClosed();
-        return () -> new Iterator<FileStore>() {
-
-            private int i = 0;
-
-            @Override
-            public boolean hasNext() {
-                return i < 1;
-            }
-
-            @Override
-            public FileStore next() {
-                if (i < 1) {
-                    i++;
-                    return fileStore;
-                } else {
-                    throw new NoSuchElementException();
-                }
-            }
-
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException();
-            }
-        };
-    }
-
-    @Override
-    public Set<String> supportedFileAttributeViews() {
-        checkClosed();
-        return SUPPORTED_ATTR_VIEWS;
-    }
-
-    @Override
-    public Path getPath(final String first,
-                        final String... more)
-            throws InvalidPathException {
-        checkClosed();
-        if (first == null || first.trim().isEmpty()) {
-            return new JGitFSPath(this);
-        }
-
-        if (more == null || more.length == 0) {
-            return JGitPathImpl.create(this,
-                                       first,
-                                       JGitPathImpl.DEFAULT_REF_TREE + "@" + name,
-                                       false);
-        }
-
-        final StringBuilder sb = new StringBuilder();
-        for (final String segment : more) {
-            if (segment.length() > 0) {
-                if (sb.length() > 0) {
-                    sb.append(getSeparator());
-                }
-                sb.append(segment);
-            }
-        }
-        return JGitPathImpl.create(this,
-                                   sb.toString(),
-                                   first + "@" + name,
-                                   false);
-    }
-
-    @Override
-    public PathMatcher getPathMatcher(final String syntaxAndPattern)
-            throws IllegalArgumentException, PatternSyntaxException, UnsupportedOperationException {
-        checkClosed();
-        checkNotEmpty("syntaxAndPattern",
-                      syntaxAndPattern);
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public UserPrincipalLookupService getUserPrincipalLookupService()
-            throws UnsupportedOperationException {
-        checkClosed();
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public WatchService newWatchService()
-            throws UnsupportedOperationException, IOException {
-        checkClosed();
-        final WatchService ws = new WatchService() {
-            private boolean wsClose = false;
-
-            @Override
-            public WatchKey poll() throws ClosedWatchServiceException {
-                return events.get(this).poll();
-            }
-
-            @Override
-            public WatchKey poll(long timeout,
-                                 TimeUnit unit) throws ClosedWatchServiceException, org.uberfire.java.nio.file.InterruptedException {
-                return events.get(this).poll();
-            }
-
-            @Override
-            public synchronized WatchKey take() throws ClosedWatchServiceException, InterruptedException {
-                while (true) {
-                    if (wsClose || isClosed) {
-                        throw new ClosedWatchServiceException("This service is closed.");
-                    } else if (events.get(this).size() > 0) {
-                        return events.get(this).poll();
-                    } else {
-                        try {
-                            this.wait();
-                        } catch (final java.lang.InterruptedException e) {
-                        }
-                    }
-                }
-            }
-
-            @Override
-            public boolean isClose() {
-                return isClosed;
-            }
-
-            @Override
-            public synchronized void close() throws IOException {
-                wsClose = true;
-                notifyAll();
-                watchServices.remove(this);
-            }
-
-            @Override
-            public String toString() {
-                return "WatchService{" +
-                        "FileSystem=" + JGitFileSystem.this.toString() +
-                        '}';
-            }
-        };
-        events.put(ws,
-                   new ConcurrentLinkedQueue<>());
-        watchServices.add(ws);
-        return ws;
-    }
-
-    @Override
-    public void close() throws IOException {
-        if (isClosed) {
-            return;
-        }
-        git.getRepository().close();
-        isClosed = true;
-        try {
-
-            for (final WatchService ws : new ArrayList<>(watchServices)) {
-                try {
-                    ws.close();
-                } catch (final Exception ex) {
-                    LOGGER.error("Can't close watch service [" + toString() + "]",
-                                 ex);
-                }
-            }
-            watchServices.clear();
-            events.clear();
-        } catch (final Exception ex) {
-            LOGGER.error("Error during close of WatchServices [" + toString() + "]",
-                         ex);
-        } finally {
-            provider.onCloseFileSystem(this);
-        }
-    }
-
-    private void checkClosed() throws IllegalStateException {
-        if (isClosed) {
-            throw new IllegalStateException("FileSystem is closed.");
-        }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        JGitFileSystem that = (JGitFileSystem) o;
-
-        if (fileStore != null ? !fileStore.equals(that.fileStore) : that.fileStore != null) {
-            return false;
-        }
-        if (!git.equals(that.git)) {
-            return false;
-        }
-        if (!name.equals(that.name)) {
-            return false;
-        }
-        if (!provider.equals(that.provider)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    @Override
-    public String toString() {
-        return toStringContent;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = provider.hashCode();
-        result = 31 * result + git.hashCode();
-        result = 31 * result + (fileStore != null ? fileStore.hashCode() : 0);
-        result = 31 * result + name.hashCode();
-        return result;
-    }
-
-    public void publishEvents(final Path watchable,
-                              final List<WatchEvent<?>> elist) {
-        if (this.events.isEmpty()) {
-            return;
-        }
-
-        final WatchKey wk = new WatchKey() {
-
-            @Override
-            public boolean isValid() {
-                return true;
-            }
-
-            @Override
-            public List<WatchEvent<?>> pollEvents() {
-                return new ArrayList<WatchEvent<?>>(elist);
-            }
-
-            @Override
-            public boolean reset() {
-                return isOpen();
-            }
-
-            @Override
-            public void cancel() {
-            }
-
-            @Override
-            public Watchable watchable() {
-                return watchable;
-            }
-        };
-
-        for (final Map.Entry<WatchService, Queue<WatchKey>> watchServiceQueueEntry : events.entrySet()) {
-            watchServiceQueueEntry.getValue().add(wk);
-            final WatchService ws = watchServiceQueueEntry.getKey();
-            synchronized (ws) {
-                ws.notifyAll();
-            }
-        }
-    }
-
-    @Override
-    public void dispose() {
-        if (!isClosed) {
-            close();
-        }
-        provider.onDisposeFileSystem(this);
-    }
-
-    public boolean isOnBatch() {
-        return state.equals(FileSystemState.BATCH);
-    }
-
-    public void setState(String state) {
-        try {
-            this.state = FileSystemState.valueOf(state);
-        } catch (final Exception ex) {
-            this.state = FileSystemState.NORMAL;
-        }
-    }
-
-    private CommitInfo buildCommitInfo(final String defaultMessage,
-                                       final CommentedOption op) {
-        String sessionId = null;
-        String name = null;
-        String email = null;
-        String message = defaultMessage;
-        TimeZone timeZone = null;
-        Date when = null;
-
-        if (op != null) {
-            sessionId = op.getSessionId();
-            name = op.getName();
-            email = op.getEmail();
-            if (op.getMessage() != null && !op.getMessage().trim().isEmpty()) {
-                message = op.getMessage();
-            }
-            timeZone = op.getTimeZone();
-            when = op.getWhen();
-        }
-
-        return new CommitInfo(sessionId,
-                              name,
-                              email,
-                              message,
-                              timeZone,
-                              when);
-    }
-
-    public void setBatchCommitInfo(final String defaultMessage,
-                                   final CommentedOption op) {
-        this.batchCommitInfo = buildCommitInfo(defaultMessage,
-                                               op);
-    }
-
-    public void setHadCommitOnBatchState(final Path path,
-                                         final boolean hadCommitOnBatchState) {
-        final Path root = checkNotNull("path",
-                                       path).getRoot();
-        this.hadCommitOnBatchState.put(root.getRoot(),
-                                       hadCommitOnBatchState);
-    }
-
-    public void setHadCommitOnBatchState(final boolean value) {
-        for (Map.Entry<Path, Boolean> entry : hadCommitOnBatchState.entrySet()) {
-            entry.setValue(value);
-        }
-    }
-
-    public boolean isHadCommitOnBatchState(final Path path) {
-        final Path root = checkNotNull("path",
-                                       path).getRoot();
-        return hadCommitOnBatchState.containsKey(root) ? hadCommitOnBatchState.get(root) : false;
-    }
-
-    public void setBatchCommitInfo(CommitInfo batchCommitInfo) {
-        this.batchCommitInfo = batchCommitInfo;
-    }
-
-    public CommitInfo getBatchCommitInfo() {
-        return batchCommitInfo;
-    }
-
-    public int incrementAndGetCommitCount() {
-        return numberOfCommitsSinceLastGC.incrementAndGet();
-    }
-
-    public void resetCommitCount() {
-        numberOfCommitsSinceLastGC.set(0);
-    }
-
-    int getNumberOfCommitsSinceLastGC() {
-        return numberOfCommitsSinceLastGC.get();
-    }
-
-    @Override
-    public FileSystemState getState() {
-        return state;
-    }
-
-    public void lock() {
-        try {
-            lock.lock();
-        } catch (final java.lang.InterruptedException ignored) {
-        }
-    }
-
-    public void unlock() {
-        lock.unlock();
-    }
-
-    private static class Lock {
-
-        private final AtomicBoolean isLocked = new AtomicBoolean(false);
-
-        public synchronized void lock() throws java.lang.InterruptedException {
-            while (!isLocked.compareAndSet(false,
-                                           true)) {
-                wait();
-            }
-        }
-
-        public synchronized void unlock() {
-            isLocked.set(false);
-            notifyAll();
-        }
-    }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImpl.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImpl.java
@@ -1,0 +1,593 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.jgit;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.RandomAccessFile;
+import java.net.URI;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.java.nio.IOException;
+import org.uberfire.java.nio.base.FileSystemState;
+import org.uberfire.java.nio.base.options.CommentedOption;
+import org.uberfire.java.nio.file.FileStore;
+import org.uberfire.java.nio.file.InvalidPathException;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.PathMatcher;
+import org.uberfire.java.nio.file.PatternSyntaxException;
+import org.uberfire.java.nio.file.WatchEvent;
+import org.uberfire.java.nio.file.WatchService;
+import org.uberfire.java.nio.file.attribute.UserPrincipalLookupService;
+import org.uberfire.java.nio.file.spi.FileSystemProvider;
+import org.uberfire.java.nio.fs.jgit.util.Git;
+import org.uberfire.java.nio.fs.jgit.util.model.CommitInfo;
+import org.uberfire.java.nio.fs.jgit.ws.JGitFileSystemsEventsManager;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableSet;
+import static org.eclipse.jgit.lib.Repository.shortenRefName;
+import static org.kie.soup.commons.validation.PortablePreconditions.checkNotEmpty;
+import static org.kie.soup.commons.validation.PortablePreconditions.checkNotNull;
+
+public class JGitFileSystemImpl implements JGitFileSystem {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JGitFileSystemImpl.class);
+    private static final Set<String> SUPPORTED_ATTR_VIEWS = unmodifiableSet(new HashSet<>(asList("basic",
+                                                                                                 "version")));
+    private final JGitFileSystemProvider provider;
+    private final Git git;
+    private final String toStringContent;
+    private boolean isClosed = false;
+    private final FileStore fileStore;
+    private final String name;
+    private final CredentialsProvider credential;
+    private final AtomicInteger numberOfCommitsSinceLastGC = new AtomicInteger(0);
+    private FileSystemState state = FileSystemState.NORMAL;
+    private CommitInfo batchCommitInfo = null;
+    private Map<Path, Boolean> hadCommitOnBatchState = new ConcurrentHashMap<>();
+    private Map<String, NotificationModel> oldHeadsOfPendingDiffs = new ConcurrentHashMap<>();
+    private Lock lock;
+    private JGitFileSystemsEventsManager fsEventsManager;
+
+    public JGitFileSystemImpl(final JGitFileSystemProvider provider,
+                              final Map<String, String> fullHostNames,
+                              final Git git,
+                              final String name,
+                              final CredentialsProvider credential,
+                              JGitFileSystemsEventsManager fsEventsManager) {
+        this.fsEventsManager = fsEventsManager;
+        this.provider = checkNotNull("provider",
+                                     provider);
+        this.git = checkNotNull("git",
+                                git);
+        this.name = checkNotEmpty("name",
+                                  name);
+
+        this.lock = new Lock(git.getRepository().getDirectory().toURI());
+        this.credential = checkNotNull("credential",
+                                       credential);
+        this.fileStore = new JGitFileStore(this.git.getRepository());
+        if (fullHostNames != null && !fullHostNames.isEmpty()) {
+            final StringBuilder sb = new StringBuilder();
+            final Iterator<Map.Entry<String, String>> iterator = fullHostNames.entrySet().iterator();
+            while (iterator.hasNext()) {
+                final Map.Entry<String, String> entry = iterator.next();
+                sb.append(entry.getKey()).append("://").append(entry.getValue()).append("/").append(name);
+                if (iterator.hasNext()) {
+                    sb.append("\n");
+                }
+            }
+            toStringContent = sb.toString();
+        } else {
+            toStringContent = "git://" + name;
+        }
+    }
+
+    @Override
+    public String id() {
+        return name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Git getGit() {
+        return git;
+    }
+
+    @Override
+    public CredentialsProvider getCredential() {
+        return credential;
+    }
+
+    @Override
+    public FileSystemProvider provider() {
+        return provider;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !isClosed;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public String getSeparator() {
+        return "/";
+    }
+
+    @Override
+    public Iterable<Path> getRootDirectories() {
+        checkClosed();
+        return () -> new Iterator<Path>() {
+
+            Iterator<Ref> branches = null;
+
+            @Override
+            public boolean hasNext() {
+                if (branches == null) {
+                    init();
+                }
+                return branches.hasNext();
+            }
+
+            private void init() {
+                branches = git.listRefs().iterator();
+            }
+
+            @Override
+            public Path next() {
+
+                if (branches == null) {
+                    init();
+                }
+                try {
+                    return JGitPathImpl.createRoot(JGitFileSystemImpl.this,
+                                                   "/",
+                                                   shortenRefName(branches.next().getName()) + "@" + name,
+                                                   false);
+                } catch (NoSuchElementException e) {
+                    throw new IllegalStateException(
+                            "The gitnio directory is in an invalid state. " +
+                                    "If you are an IntelliJ IDEA user, " +
+                                    "there is a known bug which requires specifying " +
+                                    "a custom directory for your git repository. " +
+                                    "You can specify a custom directory using '-Dorg.uberfire.nio.git.dir=/tmp/dir'. " +
+                                    "For more details please see https://issues.jboss.org/browse/UF-275.",
+                            e);
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    public Iterable<FileStore> getFileStores() {
+        checkClosed();
+        return () -> new Iterator<FileStore>() {
+
+            private int i = 0;
+
+            @Override
+            public boolean hasNext() {
+                return i < 1;
+            }
+
+            @Override
+            public FileStore next() {
+                if (i < 1) {
+                    i++;
+                    return fileStore;
+                } else {
+                    throw new NoSuchElementException();
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Override
+    public Set<String> supportedFileAttributeViews() {
+        checkClosed();
+        return SUPPORTED_ATTR_VIEWS;
+    }
+
+    @Override
+    public Path getPath(final String first,
+                        final String... more)
+            throws InvalidPathException {
+        checkClosed();
+        if (first == null || first.trim().isEmpty()) {
+            return new JGitFSPath(this);
+        }
+
+        if (more == null || more.length == 0) {
+            return JGitPathImpl.create(this,
+                                       first,
+                                       JGitPathImpl.DEFAULT_REF_TREE + "@" + name,
+                                       false);
+        }
+
+        final StringBuilder sb = new StringBuilder();
+        for (final String segment : more) {
+            if (segment.length() > 0) {
+                if (sb.length() > 0) {
+                    sb.append(getSeparator());
+                }
+                sb.append(segment);
+            }
+        }
+        return JGitPathImpl.create(this,
+                                   sb.toString(),
+                                   first + "@" + name,
+                                   false);
+    }
+
+    @Override
+    public PathMatcher getPathMatcher(final String syntaxAndPattern)
+            throws IllegalArgumentException, PatternSyntaxException, UnsupportedOperationException {
+        checkClosed();
+        checkNotEmpty("syntaxAndPattern",
+                      syntaxAndPattern);
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public UserPrincipalLookupService getUserPrincipalLookupService()
+            throws UnsupportedOperationException {
+        checkClosed();
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public WatchService newWatchService()
+            throws UnsupportedOperationException, IOException {
+        checkClosed();
+        return fsEventsManager.newWatchService(name);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (isClosed) {
+            return;
+        }
+        git.getRepository().close();
+        isClosed = true;
+        try {
+            fsEventsManager.close(name);
+        } catch (final Exception ex) {
+            LOGGER.error("Error during close of WatchServices [" + toString() + "]",
+                         ex);
+        } finally {
+            provider.onCloseFileSystem(this);
+        }
+    }
+
+    @Override
+    public void checkClosed() throws IllegalStateException {
+        if (isClosed) {
+            throw new IllegalStateException("FileSystem is closed.");
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            if (o != null && o instanceof JGitFileSystemProxy) {
+                o = ((JGitFileSystemProxy) o).getRealJGitFileSystem();
+            } else {
+                return false;
+            }
+        }
+
+        JGitFileSystemImpl that = (JGitFileSystemImpl) o;
+
+        if (!name.equals(that.name)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return toStringContent;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        return result;
+    }
+
+    @Override
+    public void publishEvents(final Path watchableRoot,
+                              final List<WatchEvent<?>> elist) {
+        fsEventsManager.publishEvents(name,
+                                      watchableRoot,
+                                      elist);
+    }
+
+    @Override
+    public void dispose() {
+        if (!isClosed) {
+            close();
+        }
+        provider.onDisposeFileSystem(this);
+    }
+
+    @Override
+    public boolean isOnBatch() {
+        return state.equals(FileSystemState.BATCH);
+    }
+
+    @Override
+    public void setState(String state) {
+        try {
+            this.state = FileSystemState.valueOf(state);
+        } catch (final Exception ex) {
+            this.state = FileSystemState.NORMAL;
+        }
+    }
+
+    @Override
+    public CommitInfo buildCommitInfo(final String defaultMessage,
+                                      final CommentedOption op) {
+        String sessionId = null;
+        String name = null;
+        String email = null;
+        String message = defaultMessage;
+        TimeZone timeZone = null;
+        Date when = null;
+
+        if (op != null) {
+            sessionId = op.getSessionId();
+            name = op.getName();
+            email = op.getEmail();
+            if (op.getMessage() != null && !op.getMessage().trim().isEmpty()) {
+                message = op.getMessage();
+            }
+            timeZone = op.getTimeZone();
+            when = op.getWhen();
+        }
+
+        return new CommitInfo(sessionId,
+                              name,
+                              email,
+                              message,
+                              timeZone,
+                              when);
+    }
+
+    @Override
+    public void setBatchCommitInfo(final String defaultMessage,
+                                   final CommentedOption op) {
+        this.batchCommitInfo = buildCommitInfo(defaultMessage,
+                                               op);
+    }
+
+    @Override
+    public void setHadCommitOnBatchState(final Path path,
+                                         final boolean hadCommitOnBatchState) {
+        final Path root = checkNotNull("path",
+                                       path).getRoot();
+        this.hadCommitOnBatchState.put(root.getRoot(),
+                                       hadCommitOnBatchState);
+    }
+
+    @Override
+    public void setHadCommitOnBatchState(final boolean value) {
+        for (Map.Entry<Path, Boolean> entry : hadCommitOnBatchState.entrySet()) {
+            entry.setValue(value);
+        }
+    }
+
+    @Override
+    public boolean isHadCommitOnBatchState(final Path path) {
+        final Path root = checkNotNull("path",
+                                       path).getRoot();
+        return hadCommitOnBatchState.containsKey(root) ? hadCommitOnBatchState.get(root) : false;
+    }
+
+    @Override
+    public void setBatchCommitInfo(CommitInfo batchCommitInfo) {
+        this.batchCommitInfo = batchCommitInfo;
+    }
+
+    @Override
+    public CommitInfo getBatchCommitInfo() {
+        return batchCommitInfo;
+    }
+
+    @Override
+    public int incrementAndGetCommitCount() {
+        return numberOfCommitsSinceLastGC.incrementAndGet();
+    }
+
+    @Override
+    public void resetCommitCount() {
+        numberOfCommitsSinceLastGC.set(0);
+    }
+
+    @Override
+    public int getNumberOfCommitsSinceLastGC() {
+        return numberOfCommitsSinceLastGC.get();
+    }
+
+    @Override
+    public FileSystemState getState() {
+        return state;
+    }
+
+    @Override
+    public void lock() {
+        lock.lock();
+    }
+
+    @Override
+    public void unlock() {
+        lock.unlock();
+    }
+
+    //testing purposes
+    public boolean isLocked() {
+        return lock.isLocked();
+    }
+
+    public static class Lock {
+
+        private ReentrantLock lock = new ReentrantLock(true);
+        private FileLock physicalLock;
+        private java.nio.file.Path lockFile;
+        private FileChannel fileChannel;
+
+        public Lock(URI repoURI) {
+            this.lockFile = createLockInfra(repoURI);
+        }
+
+        public void lock() {
+            lock.lock();
+
+            if (needToCreatePhysicalLock()) {
+                physicalLockOnFS();
+            }
+        }
+
+        private boolean needToCreatePhysicalLock() {
+            return ((physicalLock == null || !physicalLock.isValid()) && lock.getHoldCount() == 1);
+        }
+
+        public boolean isLocked() {
+            return lock.isLocked();
+        }
+
+        public void unlock() {
+            if (lock.isLocked()) {
+                if (releasePhysicalLock()) {
+                    physicalUnLockOnFS();
+                }
+                lock.unlock();
+            }
+        }
+
+        private boolean releasePhysicalLock() {
+            return physicalLock != null && physicalLock.isValid() && lock.isLocked() && lock.getHoldCount() == 1;
+        }
+
+        java.nio.file.Path createLockInfra(URI uri) {
+            java.nio.file.Path lockFile = null;
+            try {
+                java.nio.file.Path repo = Paths.get(uri);
+                lockFile = repo.resolve("db.lock");
+                Files.createFile(lockFile);
+            } catch (FileAlreadyExistsException ignored) {
+            } catch (Exception e) {
+                LOGGER.error("Error building lock infra [" + toString() + "]",
+                             e);
+            }
+            return lockFile;
+        }
+
+        void physicalLockOnFS() {
+            try {
+                File file = lockFile.toFile();
+                RandomAccessFile raf = new RandomAccessFile(file,
+                                                            "rw");
+                fileChannel = raf.getChannel();
+                physicalLock = fileChannel.lock();
+            } catch (FileNotFoundException e) {
+                LOGGER.error("Error during lock of FS [" + toString() + "]",
+                             e);
+            } catch (java.io.IOException e) {
+                LOGGER.error("Error during lock of FS [" + toString() + "]",
+                             e);
+            }
+        }
+
+        void physicalUnLockOnFS() {
+            try {
+                physicalLock.release();
+                fileChannel.close();
+                fileChannel = null;
+                physicalLock = null;
+            } catch (java.io.IOException e) {
+                LOGGER.error("Error during unlock of FS [" + toString() + "]",
+                             e);
+            }
+        }
+    }
+
+    @Override
+    public void addOldHeadsOfPendingDiffs(String branchName,
+                                          NotificationModel notificationModel) {
+        oldHeadsOfPendingDiffs.put(branchName,
+                                   notificationModel);
+    }
+
+    @Override
+    public Map<String, NotificationModel> getOldHeadsOfPendingDiffs() {
+        return oldHeadsOfPendingDiffs;
+    }
+
+    @Override
+    public boolean hasOldHeadsOfPendingDiffs() {
+        return !oldHeadsOfPendingDiffs.isEmpty();
+    }
+
+    @Override
+    public void clearOldHeadsOfPendingDiffs() {
+        oldHeadsOfPendingDiffs = new ConcurrentHashMap<>();
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderConfiguration.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderConfiguration.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit;
+
+import java.io.File;
+
+import org.eclipse.jgit.api.ListBranchCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.commons.config.ConfigProperties;
+
+import static org.eclipse.jgit.lib.Constants.DEFAULT_REMOTE_NAME;
+
+public class JGitFileSystemProviderConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JGitFileSystemProviderConfiguration.class);
+
+    public static final String GIT_ENV_KEY_DEFAULT_REMOTE_NAME = DEFAULT_REMOTE_NAME;
+
+    public static final String GIT_DAEMON_ENABLED = "org.uberfire.nio.git.daemon.enabled";
+    public static final String GIT_SSH_ENABLED = "org.uberfire.nio.git.ssh.enabled";
+    public static final String GIT_NIO_DIR = "org.uberfire.nio.git.dir";
+    public static final String GIT_NIO_DIR_NAME = "org.uberfire.nio.git.dirname";
+    public static final String ENABLE_GIT_KETCH = "org.uberfire.nio.git.ketch";
+    public static final String HOOK_DIR = "org.uberfire.nio.git.hooks";
+    public static final String GIT_DAEMON_HOST = "org.uberfire.nio.git.daemon.host";
+    public static final String GIT_DAEMON_HOSTNAME = "org.uberfire.nio.git.daemon.hostname";
+    public static final String GIT_DAEMON_PORT = "org.uberfire.nio.git.daemon.port";
+    public static final String GIT_SSH_HOST = "org.uberfire.nio.git.ssh.host";
+    public static final String GIT_SSH_HOSTNAME = "org.uberfire.nio.git.ssh.hostname";
+    public static final String GIT_SSH_PORT = "org.uberfire.nio.git.ssh.port";
+    public static final String GIT_SSH_CERT_DIR = "org.uberfire.nio.git.ssh.cert.dir";
+    public static final String GIT_SSH_IDLE_TIMEOUT = "org.uberfire.nio.git.ssh.idle.timeout";
+    public static final String GIT_SSH_ALGORITHM = "org.uberfire.nio.git.ssh.algorithm";
+    public static final String GIT_SSH_PASSPHRASE = "org.uberfire.nio.git.ssh.passphrase";
+    public static final String GIT_GC_LIMIT = "org.uberfire.nio.git.gc.limit";
+    public static final String HTTP_PROXY_USER = "http.proxyUser";
+    public static final String HTTP_PROXY_PASSWORD = "http.proxyPassword";
+    public static final String HTTPS_PROXY_USER = "https.proxyUser";
+    public static final String HTTPS_PROXY_PASSWORD = "https.proxyPassword";
+    public static final String USER_DIR = "user.dir";
+    public static final String JGIT_CACHE_INSTANCES = "org.uberfire.nio.jgit.cache.instances";
+
+    public static final String GIT_ENV_KEY_DEST_PATH = "out-dir";
+    public static final String GIT_ENV_KEY_USER_NAME = "username";
+    public static final String GIT_ENV_KEY_PASSWORD = "password";
+    public static final String GIT_ENV_KEY_INIT = "init";
+    public static final String SCHEME = "git";
+    public static final int SCHEME_SIZE = (SCHEME + "://").length();
+    public static final int DEFAULT_SCHEME_SIZE = ("default://").length();
+    public static final String REPOSITORIES_CONTAINER_DIR = ".niogit";
+    public static final String SSH_FILE_CERT_CONTAINER_DIR = ".security";
+    public static final String DEFAULT_HOST_NAME = "localhost";
+    public static final String DEFAULT_HOST_ADDR = "127.0.0.1";
+    public static final String DEFAULT_DAEMON_DEFAULT_ENABLED = "true";
+    public static final String DEFAULT_DAEMON_DEFAULT_PORT = "9418";
+    public static final String DEFAULT_SSH_ENABLED = "true";
+    public static final String DEFAULT_SSH_PORT = "8001";
+    public static final String DEFAULT_SSH_IDLE_TIMEOUT = "10000";
+    public static final String DEFAULT_SSH_ALGORITHM = "DSA";
+    public static final String DEFAULT_SSH_CERT_PASSPHRASE = "";
+    public static final String DEFAULT_COMMIT_LIMIT_TO_GC = "20";
+    public static final String DEFAULT_JGIT_FILE_SYSTEM_INSTANCES_CACHE = "20";
+    public static final String DEFAULT_GIT_ENV_KEY_MIGRATE_FROM = "migrate-from";
+    public static final String DEFAULT_ENABLE_GIT_KETCH = "false";
+
+    private int commitLimit;
+    private boolean daemonEnabled;
+    private int daemonPort;
+    private String daemonHostAddr;
+    private String daemonHostName;
+
+    private boolean sshEnabled;
+    private int sshPort;
+    private String sshHostAddr;
+    private String sshHostName;
+    private File sshFileCertDir;
+    private String sshAlgorithm;
+    private String sshPassphrase;
+    private String sshIdleTimeout;
+
+    private File gitReposParentDir;
+
+    private File hookDir;
+
+    boolean enableKetch = false;
+    private String httpProxyUser;
+    private String httpProxyPassword;
+    private String httpsProxyUser;
+    private String httpsProxyPassword;
+    private int jgitFileSystemsInstancesCache;
+
+    public void load(ConfigProperties systemConfig) {
+        LOG.debug("Configuring from properties:");
+
+        final String currentDirectory = System.getProperty(USER_DIR);
+        final ConfigProperties.ConfigProperty enableKetchProp = systemConfig.get(ENABLE_GIT_KETCH,
+                                                                                 DEFAULT_ENABLE_GIT_KETCH);
+        final ConfigProperties.ConfigProperty hookDirProp = systemConfig.get(HOOK_DIR,
+                                                                             null);
+        final ConfigProperties.ConfigProperty bareReposDirProp = systemConfig.get(GIT_NIO_DIR,
+                                                                                  currentDirectory);
+        final ConfigProperties.ConfigProperty reposDirNameProp = systemConfig.get(GIT_NIO_DIR_NAME,
+                                                                                  REPOSITORIES_CONTAINER_DIR);
+        final ConfigProperties.ConfigProperty enabledProp = systemConfig.get(GIT_DAEMON_ENABLED,
+                                                                             DEFAULT_DAEMON_DEFAULT_ENABLED);
+        final ConfigProperties.ConfigProperty hostProp = systemConfig.get(GIT_DAEMON_HOST,
+                                                                          DEFAULT_HOST_ADDR);
+        final ConfigProperties.ConfigProperty hostNameProp = systemConfig.get(GIT_DAEMON_HOSTNAME,
+                                                                              hostProp.isDefault() ? DEFAULT_HOST_NAME : hostProp.getValue());
+        final ConfigProperties.ConfigProperty portProp = systemConfig.get(GIT_DAEMON_PORT,
+                                                                          DEFAULT_DAEMON_DEFAULT_PORT);
+        final ConfigProperties.ConfigProperty sshEnabledProp = systemConfig.get(GIT_SSH_ENABLED,
+                                                                                DEFAULT_SSH_ENABLED);
+        final ConfigProperties.ConfigProperty sshHostProp = systemConfig.get(GIT_SSH_HOST,
+                                                                             DEFAULT_HOST_ADDR);
+        final ConfigProperties.ConfigProperty sshHostNameProp = systemConfig.get(GIT_SSH_HOSTNAME,
+                                                                                 sshHostProp.isDefault() ? DEFAULT_HOST_NAME : sshHostProp.getValue());
+        final ConfigProperties.ConfigProperty sshPortProp = systemConfig.get(GIT_SSH_PORT,
+                                                                             DEFAULT_SSH_PORT);
+        final ConfigProperties.ConfigProperty sshCertDirProp = systemConfig.get(GIT_SSH_CERT_DIR,
+                                                                                currentDirectory);
+        final ConfigProperties.ConfigProperty sshIdleTimeoutProp = systemConfig.get(GIT_SSH_IDLE_TIMEOUT,
+                                                                                    DEFAULT_SSH_IDLE_TIMEOUT);
+        final ConfigProperties.ConfigProperty sshAlgorithmProp = systemConfig.get(GIT_SSH_ALGORITHM,
+                                                                                  DEFAULT_SSH_ALGORITHM);
+        final ConfigProperties.ConfigProperty sshPassphraseProp = systemConfig.get(GIT_SSH_PASSPHRASE,
+                                                                                   DEFAULT_SSH_CERT_PASSPHRASE);
+        final ConfigProperties.ConfigProperty commitLimitProp = systemConfig.get(GIT_GC_LIMIT,
+                                                                                 DEFAULT_COMMIT_LIMIT_TO_GC);
+
+        final ConfigProperties.ConfigProperty httpProxyUserProp = systemConfig.get(HTTP_PROXY_USER,
+                                                                                   null);
+        final ConfigProperties.ConfigProperty httpProxyPasswordProp = systemConfig.get(HTTP_PROXY_PASSWORD,
+                                                                                       null);
+        final ConfigProperties.ConfigProperty httpsProxyUserProp = systemConfig.get(HTTPS_PROXY_USER,
+                                                                                    null);
+        final ConfigProperties.ConfigProperty httpsProxyPasswordProp = systemConfig.get(HTTPS_PROXY_PASSWORD,
+                                                                                        null);
+
+        final ConfigProperties.ConfigProperty jgitFileSystemsInstancesCacheProp = systemConfig.get(JGIT_CACHE_INSTANCES,
+                                                                                                   DEFAULT_JGIT_FILE_SYSTEM_INSTANCES_CACHE);
+
+        httpProxyUser = httpProxyUserProp.getValue();
+        httpProxyPassword = httpProxyPasswordProp.getValue();
+        httpsProxyUser = httpsProxyUserProp.getValue();
+        httpsProxyPassword = httpsProxyPasswordProp.getValue();
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(systemConfig.getConfigurationSummary("Summary of JGit configuration:"));
+        }
+
+        if (enableKetchProp != null && enableKetchProp.getValue() != null) {
+            enableKetch = enableKetchProp.getBooleanValue();
+        }
+
+        if (hookDirProp != null && hookDirProp.getValue() != null) {
+            hookDir = new File(hookDirProp.getValue());
+            if (!hookDir.exists()) {
+                hookDir = null;
+            }
+        }
+
+        gitReposParentDir = new File(bareReposDirProp.getValue(),
+                                     reposDirNameProp.getValue());
+        commitLimit = commitLimitProp.getIntValue();
+
+        jgitFileSystemsInstancesCache = jgitFileSystemsInstancesCacheProp.getIntValue();
+
+        if (jgitFileSystemsInstancesCache < 1) {
+            jgitFileSystemsInstancesCache = Integer.valueOf(DEFAULT_JGIT_FILE_SYSTEM_INSTANCES_CACHE);
+        }
+
+        daemonEnabled = enabledProp.getBooleanValue();
+        if (daemonEnabled) {
+            daemonPort = portProp.getIntValue();
+            daemonHostAddr = hostProp.getValue();
+            daemonHostName = hostNameProp.getValue();
+        }
+
+        sshEnabled = sshEnabledProp.getBooleanValue();
+        if (sshEnabled) {
+            sshPort = sshPortProp.getIntValue();
+            sshHostAddr = sshHostProp.getValue();
+            sshHostName = sshHostNameProp.getValue();
+            sshFileCertDir = new File(sshCertDirProp.getValue(),
+                                      SSH_FILE_CERT_CONTAINER_DIR);
+            sshAlgorithm = sshAlgorithmProp.getValue();
+            sshIdleTimeout = sshIdleTimeoutProp.getValue();
+            try {
+                Integer.valueOf(sshIdleTimeout);
+            } catch (final NumberFormatException exception) {
+                LOG.error("SSH Idle Timeout value is not a valid integer - Parameter is ignored, now using default value.");
+                sshIdleTimeout = DEFAULT_SSH_IDLE_TIMEOUT;
+            }
+        }
+        sshPassphrase = sshPassphraseProp.getValue();
+    }
+
+    public boolean httpProxyIsDefined() {
+        return (httpProxyUser != null &&
+                httpProxyPassword != null) ||
+                (httpsProxyUser != null &&
+                        httpsProxyPassword != null);
+    }
+
+    public int getCommitLimit() {
+        return commitLimit;
+    }
+
+    public boolean isDaemonEnabled() {
+        return daemonEnabled;
+    }
+
+    public int getDaemonPort() {
+        return daemonPort;
+    }
+
+    public String getDaemonHostAddr() {
+        return daemonHostAddr;
+    }
+
+    public String getDaemonHostName() {
+        return daemonHostName;
+    }
+
+    public boolean isSshEnabled() {
+        return sshEnabled;
+    }
+
+    public int getSshPort() {
+        return sshPort;
+    }
+
+    public String getSshHostAddr() {
+        return sshHostAddr;
+    }
+
+    public String getSshHostName() {
+        return sshHostName;
+    }
+
+    public File getSshFileCertDir() {
+        return sshFileCertDir;
+    }
+
+    public String getSshAlgorithm() {
+        return sshAlgorithm;
+    }
+
+    public String getSshPassphrase() {
+        return sshPassphrase;
+    }
+
+    public String getSshIdleTimeout() {
+        return sshIdleTimeout;
+    }
+
+    public File getGitReposParentDir() {
+        return gitReposParentDir;
+    }
+
+    public File getHookDir() {
+        return hookDir;
+    }
+
+    public boolean isEnableKetch() {
+        return enableKetch;
+    }
+
+    public String getHttpProxyUser() {
+        return httpProxyUser;
+    }
+
+    public String getHttpProxyPassword() {
+        return httpProxyPassword;
+    }
+
+    public String getHttpsProxyUser() {
+        return httpsProxyUser;
+    }
+
+    public String getHttpsProxyPassword() {
+        return httpsProxyPassword;
+    }
+
+    public int getJgitFileSystemsInstancesCache() {
+        return jgitFileSystemsInstancesCache;
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProxy.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProxy.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.jgit;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.uberfire.java.nio.IOException;
+import org.uberfire.java.nio.base.FileSystemState;
+import org.uberfire.java.nio.base.options.CommentedOption;
+import org.uberfire.java.nio.file.FileStore;
+import org.uberfire.java.nio.file.InvalidPathException;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.PathMatcher;
+import org.uberfire.java.nio.file.PatternSyntaxException;
+import org.uberfire.java.nio.file.WatchEvent;
+import org.uberfire.java.nio.file.WatchService;
+import org.uberfire.java.nio.file.attribute.UserPrincipalLookupService;
+import org.uberfire.java.nio.file.spi.FileSystemProvider;
+import org.uberfire.java.nio.fs.jgit.util.Git;
+import org.uberfire.java.nio.fs.jgit.util.model.CommitInfo;
+
+public class JGitFileSystemProxy implements JGitFileSystem {
+
+    private String fsName;
+    private Supplier<JGitFileSystem> cachedSupplier;
+
+    public JGitFileSystemProxy(String fsName,
+                               Supplier<JGitFileSystem> cachedSupplier) {
+        this.fsName = fsName;
+
+        this.cachedSupplier = cachedSupplier;
+    }
+
+    @Override
+    public String getName() {
+        return fsName;
+    }
+
+    @Override
+    public Git getGit() {
+        return cachedSupplier.get().getGit();
+    }
+
+    @Override
+    public CredentialsProvider getCredential() {
+        return cachedSupplier.get().getCredential();
+    }
+
+    @Override
+    public void checkClosed() throws IllegalStateException {
+        cachedSupplier.get().checkClosed();
+    }
+
+    @Override
+    public void publishEvents(Path watchable,
+                              List<WatchEvent<?>> elist) {
+        cachedSupplier.get().publishEvents(watchable,
+                                           elist);
+    }
+
+    @Override
+    public boolean isOnBatch() {
+        return cachedSupplier.get().isOnBatch();
+    }
+
+    @Override
+    public void setState(String state) {
+        cachedSupplier.get().setState(state);
+    }
+
+    @Override
+    public CommitInfo buildCommitInfo(String defaultMessage,
+                                      CommentedOption op) {
+        return cachedSupplier.get().buildCommitInfo(defaultMessage,
+                                                    op);
+    }
+
+    @Override
+    public void setBatchCommitInfo(String defaultMessage,
+                                   CommentedOption op) {
+        cachedSupplier.get().setBatchCommitInfo(defaultMessage,
+                                                op);
+    }
+
+    @Override
+    public void setHadCommitOnBatchState(Path path,
+                                         boolean hadCommitOnBatchState) {
+        cachedSupplier.get().setHadCommitOnBatchState(path,
+                                                      hadCommitOnBatchState);
+    }
+
+    @Override
+    public void setHadCommitOnBatchState(boolean value) {
+        cachedSupplier.get().setHadCommitOnBatchState(value);
+    }
+
+    @Override
+    public boolean isHadCommitOnBatchState(Path path) {
+        return cachedSupplier.get().isHadCommitOnBatchState(path);
+    }
+
+    @Override
+    public void setBatchCommitInfo(CommitInfo batchCommitInfo) {
+        cachedSupplier.get().setBatchCommitInfo(batchCommitInfo);
+    }
+
+    @Override
+    public CommitInfo getBatchCommitInfo() {
+        return cachedSupplier.get().getBatchCommitInfo();
+    }
+
+    @Override
+    public int incrementAndGetCommitCount() {
+        return cachedSupplier.get().incrementAndGetCommitCount();
+    }
+
+    @Override
+    public void resetCommitCount() {
+        cachedSupplier.get().resetCommitCount();
+    }
+
+    @Override
+    public int getNumberOfCommitsSinceLastGC() {
+        return cachedSupplier.get().getNumberOfCommitsSinceLastGC();
+    }
+
+    @Override
+    public void lock() {
+        cachedSupplier.get().lock();
+    }
+
+    @Override
+    public void unlock() {
+        cachedSupplier.get().unlock();
+    }
+
+    @Override
+    public void addOldHeadsOfPendingDiffs(String branchName,
+                                          NotificationModel notificationModel) {
+        cachedSupplier.get().addOldHeadsOfPendingDiffs(branchName,
+                                                       notificationModel);
+    }
+
+    @Override
+    public Map<String, NotificationModel> getOldHeadsOfPendingDiffs() {
+        return cachedSupplier.get().getOldHeadsOfPendingDiffs();
+    }
+
+    @Override
+    public boolean hasOldHeadsOfPendingDiffs() {
+        return cachedSupplier.get().hasOldHeadsOfPendingDiffs();
+    }
+
+    @Override
+    public void clearOldHeadsOfPendingDiffs() {
+        cachedSupplier.get().clearOldHeadsOfPendingDiffs();
+    }
+
+    @Override
+    public FileSystemProvider provider() {
+        return cachedSupplier.get().provider();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return cachedSupplier.get().isOpen();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public String getSeparator() {
+        return "/";
+    }
+
+    @Override
+    public Iterable<Path> getRootDirectories() {
+        return cachedSupplier.get().getRootDirectories();
+    }
+
+    @Override
+    public Iterable<FileStore> getFileStores() {
+        return cachedSupplier.get().getFileStores();
+    }
+
+    @Override
+    public Set<String> supportedFileAttributeViews() {
+        return cachedSupplier.get().supportedFileAttributeViews();
+    }
+
+    @Override
+    public Path getPath(String first,
+                        String... more) throws InvalidPathException {
+        return cachedSupplier.get().getPath(first,
+                                            more);
+    }
+
+    @Override
+    public PathMatcher getPathMatcher(String syntaxAndPattern) throws IllegalArgumentException, PatternSyntaxException, UnsupportedOperationException {
+        return cachedSupplier.get().getPathMatcher(syntaxAndPattern);
+    }
+
+    @Override
+    public UserPrincipalLookupService getUserPrincipalLookupService() throws UnsupportedOperationException {
+        return cachedSupplier.get().getUserPrincipalLookupService();
+    }
+
+    @Override
+    public WatchService newWatchService() throws UnsupportedOperationException, IOException {
+        return cachedSupplier.get().newWatchService();
+    }
+
+    @Override
+    public void close() {
+        cachedSupplier.get().close();
+    }
+
+    @Override
+    public void dispose() {
+        cachedSupplier.get().dispose();
+    }
+
+    @Override
+    public String id() {
+        return fsName;
+    }
+
+    @Override
+    public FileSystemState getState() {
+        return cachedSupplier.get().getState();
+    }
+
+    public JGitFileSystem getRealJGitFileSystem() {
+        return cachedSupplier.get();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return cachedSupplier.get().equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return cachedSupplier.get().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return cachedSupplier.get().toString();
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/git/KetchCustomReceivePack.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/git/KetchCustomReceivePack.java
@@ -17,9 +17,6 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.ReceiveCommand;
 import org.eclipse.jgit.transport.ReceivePack;
 
-/**
- * TODO: update me
- */
 public class KetchCustomReceivePack extends ReceivePack {
 
     public KetchCustomReceivePack(final Repository into) {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemsCache.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemsCache.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.jgit.manager;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import org.kie.soup.commons.validation.PortablePreconditions;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystem;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProxy;
+
+public class JGitFileSystemsCache {
+
+    //supplier for fs
+    final Map<String, Supplier<JGitFileSystem>> fileSystemsSuppliers = new ConcurrentHashMap<>();
+
+    //limited ammount of real instances of FS
+    final Map<String, Supplier<JGitFileSystem>> memoizedSuppliers;
+
+    public JGitFileSystemsCache(JGitFileSystemProviderConfiguration config) {
+        memoizedSuppliers = (Map) Collections.synchronizedMap(new LinkedHashMap<String, Supplier<JGitFileSystem>>(config.getJgitFileSystemsInstancesCache() + 1,
+                                                                                                                  0.75f,
+                                                                                                                  true) {
+            public boolean removeEldestEntry(Map.Entry eldest) {
+                return size() > config.getJgitFileSystemsInstancesCache();
+            }
+        });
+    }
+
+    public void addSupplier(String fsKey,
+                            Supplier<JGitFileSystem> createFSSupplier) {
+        PortablePreconditions.checkNotNull("fsKey",
+                                           fsKey);
+        PortablePreconditions.checkNotNull("fsSupplier",
+                                           createFSSupplier);
+
+        fileSystemsSuppliers.putIfAbsent(fsKey,
+                                         createFSSupplier);
+
+        createMemoizedSupplier(fsKey,
+                               createFSSupplier);
+    }
+
+    Supplier<JGitFileSystem> createMemoizedSupplier(String fsKey,
+                                                    Supplier<JGitFileSystem> createFSSupplier) {
+        Supplier<JGitFileSystem> memoizedFSSupplier = MemoizedFileSystemsSupplier.of(createFSSupplier);
+        memoizedSuppliers.putIfAbsent(fsKey,
+                                      memoizedFSSupplier);
+        return memoizedFSSupplier;
+    }
+
+    public void remove(String fsName) {
+        fileSystemsSuppliers.remove(fsName);
+        memoizedSuppliers.remove(fsName);
+    }
+
+    public JGitFileSystem get(String fsName) {
+
+        Supplier<JGitFileSystem> memoizedSupplier = memoizedSuppliers.get(fsName);
+        if (memoizedSupplier != null) {
+            return new JGitFileSystemProxy(fsName,
+                                           memoizedSupplier);
+        } else if (fileSystemsSuppliers.get(fsName) != null) {
+            Supplier<JGitFileSystem> newMemoizedSupplier = createMemoizedSupplier(fsName,
+                                                                                  fileSystemsSuppliers.get(fsName));
+            return new JGitFileSystemProxy(fsName,
+                                           newMemoizedSupplier);
+        }
+        return null;
+    }
+
+    public void clear() {
+        memoizedSuppliers.clear();
+        fileSystemsSuppliers.clear();
+    }
+
+    public boolean containsKey(String fsName) {
+        return fileSystemsSuppliers.containsKey(fsName);
+    }
+
+    public Collection<String> getFileSystems() {
+        return fileSystemsSuppliers.keySet();
+    }
+
+    public JGitFileSystemsCacheInfo getCacheInfo() {
+        return new JGitFileSystemsCacheInfo();
+    }
+
+    public class JGitFileSystemsCacheInfo {
+
+        public int fileSystemsCacheSize() {
+            return memoizedSuppliers.size();
+        }
+
+        public Set<String> fileSystemsCacheKeys() {
+            return memoizedSuppliers.keySet();
+        }
+
+        @Override
+        public String toString() {
+            return "JGitFileSystemsCacheInfo{fileSystemsCacheSize[" + fileSystemsCacheSize() + "], fileSystemsCacheKeys[" + fileSystemsCacheKeys() + "]}";
+        }
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemsManager.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemsManager.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit.manager;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystem;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemImpl;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration;
+import org.uberfire.java.nio.fs.jgit.util.Git;
+import org.uberfire.java.nio.fs.jgit.ws.JGitFileSystemsEventsManager;
+
+import static org.eclipse.jgit.lib.Constants.DOT_GIT_EXT;
+
+public class JGitFileSystemsManager {
+
+    private final Set<String> closedFileSystems = new HashSet<>();
+
+    private final Set<String> fileSystemsRoot = new HashSet<>();
+
+    private final JGitFileSystemProvider jGitFileSystemProvider;
+
+    private final JGitFileSystemsCache fsCache;
+
+    public JGitFileSystemsManager(JGitFileSystemProvider jGitFileSystemProvider,
+                                  JGitFileSystemProviderConfiguration config) {
+        this.jGitFileSystemProvider = jGitFileSystemProvider;
+        fsCache = new JGitFileSystemsCache(config);
+    }
+
+    public void newFileSystem(Supplier<Map<String, String>> fullHostNames,
+                              Supplier<Git> git,
+                              Supplier<String> fsName,
+                              Supplier<CredentialsProvider> credential,
+                              Supplier<JGitFileSystemsEventsManager> fsManager) {
+
+        Supplier<JGitFileSystem> fsSupplier = createFileSystemSupplier(fullHostNames,
+                                                                       git,
+                                                                       fsName,
+                                                                       credential,
+                                                                       fsManager);
+
+        fsCache.addSupplier(fsName.get(),
+                            fsSupplier);
+        fileSystemsRoot.addAll(parseFSRoots(fsName.get()));
+    }
+
+    List<String> parseFSRoots(String fsKey) {
+        List<String> roots = new ArrayList<>();
+        fsKey = cleanupFsName(fsKey);
+        int index = fsKey.indexOf("/");
+        while (index >= 0) {
+            roots.add(fsKey.substring(0,
+                                      index));
+            index = fsKey.indexOf("/",
+                                  index + 1);
+        }
+        roots.add(fsKey);
+        return roots;
+    }
+
+    private String cleanupFsName(String fsKey) {
+        if (fsKey.startsWith("/")) {
+            fsKey = fsKey.substring(1);
+        }
+        if (fsKey.endsWith("/")) {
+            fsKey = fsKey.substring(0,
+                                    fsKey.length() - 1);
+        }
+
+        return fsKey;
+    }
+
+    private Supplier<JGitFileSystem> createFileSystemSupplier(Supplier<Map<String, String>> fullHostNames,
+                                                              Supplier<Git> git,
+                                                              Supplier<String> fsName,
+                                                              Supplier<CredentialsProvider> credential,
+                                                              Supplier<JGitFileSystemsEventsManager> fsManager) {
+
+        return () -> newFileSystem(fullHostNames.get(),
+                                   git.get(),
+                                   fsName.get(),
+                                   credential.get(),
+                                   fsManager.get());
+    }
+
+    private JGitFileSystem newFileSystem(Map<String, String> fullHostNames,
+                                         Git git,
+                                         String fsName,
+                                         CredentialsProvider credential,
+                                         JGitFileSystemsEventsManager fsEventsManager) {
+        final JGitFileSystem fs = new JGitFileSystemImpl(jGitFileSystemProvider,
+                                                         fullHostNames,
+                                                         git,
+                                                         fsName,
+                                                         credential,
+                                                         fsEventsManager);
+
+        fs.getGit().gc();
+
+        return fs;
+    }
+
+    public void remove(String realFSKey) {
+        fsCache.remove(realFSKey);
+        closedFileSystems.remove(realFSKey);
+    }
+
+    public JGitFileSystem get(String fsName) {
+        return fsCache.get(fsName);
+    }
+
+    public void clear() {
+        fsCache.clear();
+        closedFileSystems.clear();
+        fileSystemsRoot.clear();
+    }
+
+    public boolean containsKey(String fsName) {
+
+        return fsCache.getFileSystems().contains(fsName) && !closedFileSystems.contains(fsName);
+    }
+
+    public boolean containsRoot(String fsName) {
+        return fileSystemsRoot.contains(fsName);
+    }
+
+    public void addClosedFileSystems(JGitFileSystem fileSystem) {
+        String realFSKey = fileSystem.getName();
+        closedFileSystems.add(realFSKey);
+        List<String> roots = parseFSRoots(fileSystem.getName());
+        fileSystemsRoot.removeAll(roots);
+    }
+
+    public boolean allTheFSAreClosed() {
+        return closedFileSystems.size() == fsCache.getFileSystems().size();
+    }
+
+    public JGitFileSystem get(Repository db) {
+        String key = extractFSNameFromRepo(db);
+        return fsCache.get(key);
+    }
+
+    public Set<JGitFileSystem> getOpenFileSystems() {
+        return fsCache.getFileSystems().stream().filter(fsName -> !closedFileSystems.contains(fsName))
+                .map(fsName -> get(fsName)).collect(Collectors.toSet());
+    }
+
+    public JGitFileSystemsCache getFsCache() {
+        return fsCache;
+    }
+
+    private String extractFSNameFromRepo(Repository db) {
+        final String nioGitPath = ".niogit/";
+
+        String fullPath = db.getDirectory().getPath();
+
+        fullPath = fullPath.substring((fullPath.indexOf(nioGitPath) + nioGitPath.length()),
+                                      fullPath.length());
+        String fsName = fullPath.substring(0,
+                                           fullPath.indexOf(DOT_GIT_EXT));
+        return fsName;
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/manager/MemoizedFileSystemsSupplier.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/manager/MemoizedFileSystemsSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.jgit.manager;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+
+public class MemoizedFileSystemsSupplier<T> implements Supplier<T> {
+
+    final Supplier<T> delegate;
+    ConcurrentMap<Class<?>, T> map = new ConcurrentHashMap<>(1);
+
+    private MemoizedFileSystemsSupplier(Supplier<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public T get() {
+
+        T t = this.map.computeIfAbsent(MemoizedFileSystemsSupplier.class,
+                                       k -> this.delegate.get());
+        return t;
+    }
+
+    public static <T> Supplier<T> of(Supplier<T> provider) {
+        return new MemoizedFileSystemsSupplier<>(provider);
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/CherryPick.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/CherryPick.java
@@ -28,9 +28,6 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.uberfire.java.nio.IOException;
 import org.uberfire.java.nio.fs.jgit.util.Git;
 
-/**
- * TODO: update me
- */
 public class CherryPick {
 
     private final Git git;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/ConvertRefTree.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/ConvertRefTree.java
@@ -28,9 +28,6 @@ import org.uberfire.java.nio.fs.jgit.util.Git;
 
 import static org.eclipse.jgit.lib.Constants.HEAD;
 
-/**
- * TODO: update me
- */
 public class ConvertRefTree {
 
     private final Git git;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/CreateBranch.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/CreateBranch.java
@@ -18,13 +18,11 @@ package org.uberfire.java.nio.fs.jgit.util.commands;
 
 import org.uberfire.java.nio.fs.jgit.util.GitImpl;
 
-/**
- * TODO: update me
- */
 public class CreateBranch {
 
     private final GitImpl git;
     private final String source;
+    private final String target;
 
     public CreateBranch(final GitImpl git,
                         final String source,
@@ -33,8 +31,6 @@ public class CreateBranch {
         this.source = source;
         this.target = target;
     }
-
-    private final String target;
 
     public void execute() {
         try {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/GarbageCollector.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/GarbageCollector.java
@@ -20,9 +20,6 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.internal.storage.reftree.RefTreeDatabase;
 import org.uberfire.java.nio.fs.jgit.util.GitImpl;
 
-/**
- * TODO: update me
- */
 public class GarbageCollector {
 
     private final GitImpl git;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/GetFirstCommit.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/GetFirstCommit.java
@@ -24,9 +24,6 @@ import org.eclipse.jgit.revwalk.RevSort;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.uberfire.java.nio.fs.jgit.util.Git;
 
-/**
- * TODO: update me
- */
 public class GetFirstCommit {
 
     private final Git git;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/GetLastCommit.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/GetLastCommit.java
@@ -22,9 +22,6 @@ import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.uberfire.java.nio.fs.jgit.util.Git;
 
-/**
- * TODO: update me
- */
 public class GetLastCommit {
 
     private final Git git;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/GetRef.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/GetRef.java
@@ -24,9 +24,6 @@ import org.eclipse.jgit.lib.Repository;
 
 import static org.eclipse.jgit.lib.Constants.OBJ_TREE;
 
-/**
- * TODO: update me
- */
 public class GetRef {
 
     private final Repository repo;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/GetTreeFromRef.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/GetTreeFromRef.java
@@ -20,9 +20,6 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.uberfire.java.nio.fs.jgit.util.Git;
 
-/**
- * TODO: update me
- */
 public class GetTreeFromRef {
 
     private final Git git;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/ListDiffs.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/ListDiffs.java
@@ -26,9 +26,6 @@ import org.uberfire.java.nio.fs.jgit.util.Git;
 
 import static java.util.Collections.emptyList;
 
-/**
- * TODO: update me
- */
 public class ListDiffs {
 
     private final Git git;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/ListRefs.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/ListRefs.java
@@ -22,9 +22,6 @@ import java.util.List;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 
-/**
- * TODO: update me
- */
 public class ListRefs {
 
     private final Repository repo;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/PathUtil.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/PathUtil.java
@@ -16,9 +16,6 @@
 
 package org.uberfire.java.nio.fs.jgit.util.commands;
 
-/**
- * TODO: update me
- */
 public class PathUtil {
 
     public static String normalize(final String path) {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/ResolveObjectIds.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/ResolveObjectIds.java
@@ -23,9 +23,6 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.uberfire.java.nio.fs.jgit.util.Git;
 
-/**
- * TODO: update me
- */
 public class ResolveObjectIds {
 
     private final Git git;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/ResolveRevCommit.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/ResolveRevCommit.java
@@ -23,9 +23,6 @@ import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 
-/**
- * TODO: update me
- */
 public class ResolveRevCommit {
 
     private final Repository repo;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/UpdateRemoteConfig.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/UpdateRemoteConfig.java
@@ -29,9 +29,6 @@ import org.eclipse.jgit.transport.URIish;
 import org.uberfire.commons.data.Pair;
 import org.uberfire.java.nio.fs.jgit.util.Git;
 
-/**
- * TODO: update me
- */
 public class UpdateRemoteConfig {
 
     private final Git git;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/WriteConfiguration.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/commands/WriteConfiguration.java
@@ -6,9 +6,6 @@ import java.util.function.Consumer;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.StoredConfig;
 
-/**
- * TODO: update me
- */
 public class WriteConfiguration {
 
     private final Repository repo;

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/model/PathType.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/model/PathType.java
@@ -16,9 +16,6 @@
 
 package org.uberfire.java.nio.fs.jgit.util.model;
 
-/**
- * TODO: update me
- */
 public enum PathType {
     NOT_FOUND,
     DIRECTORY,

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/JGitFileSystemWatchServices.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/JGitFileSystemWatchServices.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit.ws;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.WatchEvent;
+import org.uberfire.java.nio.file.WatchKey;
+import org.uberfire.java.nio.file.WatchService;
+import org.uberfire.java.nio.file.Watchable;
+
+public class JGitFileSystemWatchServices implements Serializable {
+
+    private final Collection<JGitWatchService> watchServices = new CopyOnWriteArrayList<>();
+
+    public JGitFileSystemWatchServices() {
+    }
+
+    public WatchService newWatchService(String fsName) {
+        final JGitWatchService ws = new JGitWatchService(fsName,
+                                                         p -> watchServices.remove(p));
+        watchServices.add(ws);
+        return ws;
+    }
+
+    public synchronized void publishEvents(Path watchable,
+                                           List<WatchEvent<?>> elist) {
+        if (watchServices.isEmpty()) {
+            return;
+        }
+
+        for (JGitWatchService ws : watchServices) {
+            ws.publish(new WatchKey() {
+
+                @Override
+                public boolean isValid() {
+                    return true;
+                }
+
+                @Override
+                public List<WatchEvent<?>> pollEvents() {
+                    return new CopyOnWriteArrayList<>(elist);
+                }
+
+                @Override
+                public boolean reset() {
+                    return !watchServices.isEmpty();
+                }
+
+                @Override
+                public void cancel() {
+                }
+
+                @Override
+                public Watchable watchable() {
+                    return watchable;
+                }
+            });
+            synchronized (ws) {
+                ws.notifyAll();
+            }
+        }
+    }
+
+    public void close() {
+        watchServices.forEach(ws -> ws.closeWithoutNotifyParent());
+        watchServices.clear();
+    }
+
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/JGitFileSystemsEventsManager.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/JGitFileSystemsEventsManager.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit.ws;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.java.nio.IOException;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.WatchEvent;
+import org.uberfire.java.nio.file.WatchService;
+import org.uberfire.java.nio.fs.jgit.ws.cluster.ClusterParameters;
+import org.uberfire.java.nio.fs.jgit.ws.cluster.JGitEventsBroadcast;
+
+public class JGitFileSystemsEventsManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JGitFileSystemsEventsManager.class);
+
+    private final Map<String, JGitFileSystemWatchServices> fsWatchServices = new ConcurrentHashMap<>();
+
+    private final ClusterParameters clusterParameters;
+
+    JGitEventsBroadcast jGitEventsBroadcast;
+
+    public JGitFileSystemsEventsManager() {
+        clusterParameters = loadClusterParameters();
+
+        if (clusterParameters.isAppFormerClustered()) {
+            setupJGitEventsBroadcast();
+        }
+    }
+
+    ClusterParameters loadClusterParameters() {
+        return new ClusterParameters();
+    }
+
+    void setupJGitEventsBroadcast() {
+        jGitEventsBroadcast = new JGitEventsBroadcast(clusterParameters,
+                                                      w -> publishEvents(w.getFsName(),
+                                                                         w.getWatchable(),
+                                                                         w.getEvents(),
+                                                                         false));
+    }
+
+    public WatchService newWatchService(String fsName)
+            throws UnsupportedOperationException, IOException {
+        fsWatchServices.putIfAbsent(fsName,
+                                    createFSWatchServicesManager());
+
+        if (jGitEventsBroadcast != null) {
+            jGitEventsBroadcast.createWatchServiceJMS(fsName);
+        }
+
+        return fsWatchServices.get(fsName).newWatchService(fsName);
+    }
+
+    JGitFileSystemWatchServices createFSWatchServicesManager() {
+        return new JGitFileSystemWatchServices();
+    }
+
+    public void publishEvents(String fsName,
+                              Path watchable,
+                              List<WatchEvent<?>> elist) {
+
+        publishEvents(fsName,
+                      watchable,
+                      elist,
+                      true);
+    }
+
+    public void publishEvents(String fsName,
+                              Path watchable,
+                              List<WatchEvent<?>> elist,
+                              boolean broadcastEvents) {
+
+        JGitFileSystemWatchServices watchService = fsWatchServices.get(fsName);
+
+        if (watchService == null) {
+            return;
+        }
+
+        watchService.publishEvents(watchable,
+                                   elist);
+
+        if (shouldIBroadcast(broadcastEvents)) {
+            jGitEventsBroadcast.broadcast(fsName,
+                                          watchable,
+                                          elist);
+        }
+    }
+
+    private boolean shouldIBroadcast(boolean broadcastEvents) {
+        return broadcastEvents && jGitEventsBroadcast != null;
+    }
+
+    public void close(String name) {
+
+        JGitFileSystemWatchServices watchService = fsWatchServices.get(name);
+
+        if (watchService != null) {
+            try {
+                watchService.close();
+            } catch (final Exception ex) {
+                LOGGER.error("Can't close watch service [" + toString() + "]",
+                             ex);
+            }
+        }
+        if (jGitEventsBroadcast != null) {
+            jGitEventsBroadcast.close();
+        }
+    }
+
+    JGitEventsBroadcast getjGitEventsBroadcast() {
+        return jGitEventsBroadcast;
+    }
+
+    Map<String, JGitFileSystemWatchServices> getFsWatchServices() {
+        return fsWatchServices;
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/JGitWatchEvent.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/JGitWatchEvent.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit.ws;
+
+import java.net.URI;
+
+import org.eclipse.jgit.diff.DiffEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.java.nio.base.WatchContext;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.Paths;
+import org.uberfire.java.nio.file.StandardWatchEventKind;
+import org.uberfire.java.nio.file.WatchEvent;
+
+public class JGitWatchEvent implements WatchEvent {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JGitWatchEvent.class);
+    private final URI oldPath;
+    private final URI newPath;
+    private final String sessionId;
+    private final String userName;
+    private final String message;
+    private final String changeType;
+
+    public JGitWatchEvent(String sessionId,
+                          String userName,
+                          String message,
+                          String changeType,
+                          Path oldPath,
+                          Path newPath) {
+
+        this.sessionId = sessionId;
+        this.userName = userName;
+        this.message = message;
+        this.changeType = changeType;
+        if (oldPath != null) {
+            System.out.println(oldPath.toUri().toString());
+        }
+        if (newPath != null) {
+            System.out.println(newPath.toUri().toString());
+        }
+        this.oldPath = oldPath != null ? oldPath.toUri() : null;
+        this.newPath = newPath != null ? newPath.toUri() : null;
+    }
+
+    @Override
+    public WatchEvent.Kind kind() {
+        DiffEntry.ChangeType changeType = DiffEntry.ChangeType.valueOf(this.changeType);
+        switch (changeType) {
+            case ADD:
+            case COPY:
+                return StandardWatchEventKind.ENTRY_CREATE;
+            case DELETE:
+                return StandardWatchEventKind.ENTRY_DELETE;
+            case MODIFY:
+                return StandardWatchEventKind.ENTRY_MODIFY;
+            case RENAME:
+                return StandardWatchEventKind.ENTRY_RENAME;
+            default:
+                throw new RuntimeException("Unsupported change type: " + changeType);
+        }
+    }
+
+    @Override
+    public int count() {
+        return 1;
+    }
+
+    @Override
+    public Object context() {
+        return new WatchContext() {
+
+            @Override
+            public Path getPath() {
+                return newPath != null ? lookup(newPath) : null;
+            }
+
+            @Override
+            public Path getOldPath() {
+                return oldPath != null ? lookup(oldPath) : null;
+            }
+
+            private Path lookup(URI uri) {
+                Path path = null;
+                try {
+                    path = Paths.get(uri);
+                } catch (Exception e) {
+                    LOGGER.error("Error trying to translate to path uri: " + uri);
+                }
+                return path;
+            }
+
+            @Override
+            public String getSessionId() {
+                return sessionId;
+            }
+
+            @Override
+            public String getMessage() {
+                return message;
+            }
+
+            @Override
+            public String getUser() {
+                return userName;
+            }
+        };
+    }
+
+    @Override
+    public String toString() {
+        return "WatchEvent{" +
+                "newPath=" + newPath +
+                ", oldPath=" + oldPath +
+                ", sessionId='" + sessionId + '\'' +
+                ", userName='" + userName + '\'' +
+                ", message='" + message + '\'' +
+                ", changeType=" + changeType +
+                '}';
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/JGitWatchService.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/JGitWatchService.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit.ws;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.uberfire.java.nio.IOException;
+import org.uberfire.java.nio.file.ClosedWatchServiceException;
+import org.uberfire.java.nio.file.InterruptedException;
+import org.uberfire.java.nio.file.WatchKey;
+import org.uberfire.java.nio.file.WatchService;
+
+public class JGitWatchService implements WatchService {
+
+    private boolean wsClose = false;
+
+    private final Queue<WatchKey> events = new ConcurrentLinkedQueue<>();
+    private final String fsName;
+    private Consumer<JGitWatchService> notifyClose;
+
+    public JGitWatchService(String fsName,
+                            Consumer<JGitWatchService> notifyClose) {
+
+        this.fsName = fsName;
+        this.notifyClose = notifyClose;
+    }
+
+    @Override
+    public WatchKey poll() throws ClosedWatchServiceException {
+        return events.poll();
+    }
+
+    @Override
+    public WatchKey poll(long timeout,
+                         TimeUnit unit) throws ClosedWatchServiceException, org.uberfire.java.nio.file.InterruptedException {
+        return events.poll();
+    }
+
+    @Override
+    public synchronized WatchKey take() throws ClosedWatchServiceException, InterruptedException {
+        while (true) {
+            if (wsClose) {
+                throw new ClosedWatchServiceException("This service is closed.");
+            } else if (events.size() > 0) {
+                return events.poll();
+            } else {
+                try {
+                    this.wait();
+                } catch (final java.lang.InterruptedException e) {
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean isClose() {
+        return wsClose;
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        wsClose = true;
+        notifyAll();
+        notifyClose.accept(this);
+    }
+
+    synchronized void closeWithoutNotifyParent() {
+        wsClose = true;
+        notifyAll();
+    }
+
+    @Override
+    public String toString() {
+        return "WatchService{" +
+                "FileSystem=" + fsName +
+                '}';
+    }
+
+    public void publish(WatchKey wk) {
+        events.add(wk);
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/cluster/ClusterParameters.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/cluster/ClusterParameters.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit.ws.cluster;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClusterParameters {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClusterParameters.class);
+
+    public static final String APPFORMER_CLUSTER = "appformer-cluster";
+    public static final String APPFORMER_DEFAULT_CLUSTER_CONFIGS = "appformer-default-cluster-configs";
+    public static final String APPFORMER_JMS_URL = "appformer-jms-url";
+    public static final String APPFORMER_JMS_USERNAME = "appformer-jms-username";
+    public static final String APPFORMER_JMS_PASSWORD = "appformer-jms-password";
+    private Boolean appFormerClustered;
+    private String jmsURL;
+    private String jmsUserName;
+    private String jmsPassword;
+
+    public ClusterParameters() {
+
+        this.appFormerClustered = Boolean.valueOf(System.getProperty(APPFORMER_CLUSTER,
+                                                                     "false"));
+        if (appFormerClustered) {
+
+            Boolean defaultConfigs = Boolean.valueOf(System.getProperty(APPFORMER_DEFAULT_CLUSTER_CONFIGS,
+                                                                        "false"));
+            if (defaultConfigs) {
+                setupDefaultConfigs();
+            } else {
+                loadConfigs();
+            }
+        }
+    }
+
+    private void setupDefaultConfigs() {
+        this.jmsURL = "tcp://localhost:61616";
+        this.jmsUserName = "admin";
+        this.jmsPassword = "admin";
+    }
+
+    private void loadConfigs() {
+        this.jmsURL = System.getProperty(APPFORMER_JMS_URL);
+        this.jmsUserName = System.getProperty(APPFORMER_JMS_USERNAME);
+        this.jmsPassword = System.getProperty(APPFORMER_JMS_PASSWORD);
+        if (jmsURL == null || jmsPassword == null || jmsPassword == null) {
+            throw new RuntimeException(buildErrorMessage().toString());
+        }
+    }
+
+    private StringBuilder buildErrorMessage() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("There is a error on appFormer cluster configurations: ");
+        sb.append(APPFORMER_CLUSTER + ": " + appFormerClustered);
+        sb.append(APPFORMER_JMS_URL + ": " + jmsURL);
+        sb.append(APPFORMER_JMS_USERNAME + ": " + jmsPassword);
+        sb.append(APPFORMER_JMS_PASSWORD + ": " + jmsPassword);
+        return sb;
+    }
+
+    public Boolean isAppFormerClustered() {
+        return appFormerClustered;
+    }
+
+    public String getJmsURL() {
+        return jmsURL;
+    }
+
+    public String getJmsUserName() {
+        return jmsUserName;
+    }
+
+    public String getJmsPassword() {
+        return jmsPassword;
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/cluster/JGitEventsBroadcast.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/cluster/JGitEventsBroadcast.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit.ws.cluster;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.ExceptionListener;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+import javax.jms.Topic;
+
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.WatchEvent;
+
+public class JGitEventsBroadcast {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JGitEventsBroadcast.class);
+    public static final String DEFAULT_APPFORMER_TOPIC = "default-appformer-topic";
+
+    private List<Session> consumerSessions = new ArrayList<>();
+    private String nodeId = UUID.randomUUID().toString();
+    private ClusterParameters clusterParameters;
+    private Consumer<WatchEventsWrapper> eventsPublisher;
+    private Connection connection;
+
+    public JGitEventsBroadcast(ClusterParameters clusterParameters,
+                               Consumer<WatchEventsWrapper> eventsPublisher) {
+        this.clusterParameters = clusterParameters;
+        this.eventsPublisher = eventsPublisher;
+        setupJMSConnection();
+    }
+
+    private void setupJMSConnection() {
+
+        String jmsURL = clusterParameters.getJmsURL();
+        String jmsUserName = clusterParameters.getJmsUserName();
+        String jmsPassword = clusterParameters.getJmsPassword();
+        ConnectionFactory factory = new ActiveMQConnectionFactory(jmsURL,
+                                                                  jmsUserName,
+                                                                  jmsPassword);
+
+        try {
+            connection = factory.createConnection();
+            connection.setExceptionListener(new JMSExceptionListener());
+            connection.start();
+        } catch (Exception e) {
+            LOGGER.error("Error connecting on JMS " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void createWatchServiceJMS(String topicName) {
+        try {
+            Session consumerSession = createConsumerSession();
+            Destination topic = getTopic(topicName,
+                                         consumerSession);
+            MessageConsumer messageConsumer = consumerSession.createConsumer(topic);
+            messageConsumer.setMessageListener(message -> topicMessageListener(message));
+        } catch (Exception e) {
+            LOGGER.error("Error creating JMS Watch Service: " + e.getMessage());
+        }
+    }
+
+    private void topicMessageListener(Message message) {
+        if (message instanceof ObjectMessage) {
+            try {
+                Serializable object = ((ObjectMessage) message).getObject();
+                if (object instanceof WatchEventsWrapper) {
+                    WatchEventsWrapper messageWrapper = (WatchEventsWrapper) object;
+                    if (!messageWrapper.getNodeId().equals(nodeId)) {
+                        eventsPublisher.accept(messageWrapper);
+                    }
+                }
+            } catch (JMSException e) {
+                LOGGER.error("Exception receiving JMS message: " + e.getMessage());
+            }
+        }
+    }
+
+    private Session createConsumerSession() throws JMSException {
+        Session session = connection.createSession(false,
+                                                   Session.AUTO_ACKNOWLEDGE);
+        consumerSessions.add(session);
+        return session;
+    }
+
+    public synchronized void broadcast(String fsName,
+                                       Path watchable,
+                                       List<WatchEvent<?>> events) {
+        Session session = null;
+        try {
+            session = connection.createSession(false,
+                                               Session.AUTO_ACKNOWLEDGE);
+            Topic topic = getTopic(fsName,
+                                   session);
+            ObjectMessage objectMessage = session.createObjectMessage(new WatchEventsWrapper(nodeId,
+                                                                                             fsName,
+                                                                                             watchable,
+                                                                                             events));
+            MessageProducer messageProducer = session.createProducer(topic);
+            messageProducer.send(objectMessage);
+        } catch (JMSException e) {
+            LOGGER.error("Exception on JMS broadcast: " + e.getMessage());
+        } finally {
+            if (session != null) {
+                try {
+                    session.close();
+                } catch (JMSException e) {
+                    LOGGER.error("Exception on closing JMS session (this could trigger a leak) " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    private Topic getTopic(String fsName,
+                           Session session) throws JMSException {
+        String topicName = DEFAULT_APPFORMER_TOPIC;
+        if (fsName.contains("/")) {
+            topicName = fsName.substring(0,
+                                         fsName.indexOf("/"));
+        }
+        return session.createTopic(topicName);
+    }
+
+    public void close() {
+        try {
+            for (Session s : consumerSessions) {
+                s.close();
+            }
+            connection.close();
+        } catch (JMSException e) {
+            LOGGER.error("Exception closing JMS connection and consumerSessions: " + e.getMessage());
+        }
+    }
+
+    private static class JMSExceptionListener implements ExceptionListener {
+
+        @Override
+        public void onException(JMSException e) {
+            LOGGER.error("JMSException: " + e.getMessage());
+        }
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/cluster/WatchEventsWrapper.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/cluster/WatchEventsWrapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit.ws.cluster;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.List;
+
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.Paths;
+import org.uberfire.java.nio.file.WatchEvent;
+
+public class WatchEventsWrapper implements Serializable {
+
+    private final String nodeId;
+    private final List<WatchEvent<?>> events;
+    private final URI watchable;
+    private final String fsName;
+
+    public WatchEventsWrapper(String nodeId,
+                              String fsName,
+                              Path watchable,
+                              List<WatchEvent<?>> events) {
+
+        this.nodeId = nodeId;
+        this.fsName = fsName;
+        this.events = events;
+        this.watchable = watchable != null ? watchable.toUri() : null;
+    }
+
+    public String getFsName() {
+        return fsName;
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public List<WatchEvent<?>> getEvents() {
+        return events;
+    }
+
+    public Path getWatchable() {
+        if (watchable == null) {
+            return null;
+        }
+        try {
+            return Paths.get(watchable);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        WatchEventsWrapper that = (WatchEventsWrapper) o;
+
+        if (nodeId != null ? !nodeId.equals(that.nodeId) : that.nodeId != null) {
+            return false;
+        }
+        if (events != null ? !events.equals(that.events) : that.events != null) {
+            return false;
+        }
+        if (watchable != null ? !watchable.equals(that.watchable) : that.watchable != null) {
+            return false;
+        }
+        return fsName != null ? fsName.equals(that.fsName) : that.fsName == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = nodeId != null ? nodeId.hashCode() : 0;
+        result = 31 * result + (events != null ? events.hashCode() : 0);
+        result = 31 * result + (watchable != null ? watchable.hashCode() : 0);
+        result = 31 * result + (fsName != null ? fsName.hashCode() : 0);
+        return result;
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderAsDefaultTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderAsDefaultTest.java
@@ -25,7 +25,7 @@ import org.uberfire.java.nio.file.Path;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
-public class JGitFileSystemProviderAsDefaultTest extends AbstractTestInfra {
+public class JGitFileSystemImplProviderAsDefaultTest extends AbstractTestInfra {
 
     @Before
     public void forceProviderToDefault() {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderCpMvTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderCpMvTest.java
@@ -33,7 +33,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Assertions.fail;
 import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
 
-public class JGitFileSystemProviderCpMvTest extends AbstractTestInfra {
+public class JGitFileSystemImplProviderCpMvTest extends AbstractTestInfra {
 
     @Test
     public void testCopyBranches() throws IOException {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderDiffTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderDiffTest.java
@@ -37,9 +37,9 @@ import org.uberfire.java.nio.fs.jgit.util.commands.CreateRepository;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
-public class JGitFileSystemProviderDiffTest extends AbstractTestInfra {
+public class JGitFileSystemImplProviderDiffTest extends AbstractTestInfra {
 
-    private Logger logger = LoggerFactory.getLogger(JGitFileSystemProviderDiffTest.class);
+    private Logger logger = LoggerFactory.getLogger(JGitFileSystemImplProviderDiffTest.class);
 
     @Test
     public void testDiffsBetweenBranches() throws IOException {
@@ -123,7 +123,7 @@ public class JGitFileSystemProviderDiffTest extends AbstractTestInfra {
         final URI newRepo = URI.create("git://diff-repo");
 
         final Map<String, Object> env = new HashMap<String, Object>() {{
-            put(JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME,
+            put(JGitFileSystemProviderConfiguration.GIT_ENV_KEY_DEFAULT_REMOTE_NAME,
                 origin.getRepository().getDirectory().toString());
         }};
 
@@ -182,7 +182,7 @@ public class JGitFileSystemProviderDiffTest extends AbstractTestInfra {
         final URI newRepo = URI.create("git://diff-repo");
 
         final Map<String, Object> env = new HashMap<String, Object>() {{
-            put(JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME,
+            put(JGitFileSystemProviderConfiguration.GIT_ENV_KEY_DEFAULT_REMOTE_NAME,
                 origin.getRepository().getDirectory().toString());
         }};
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderEncodingTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderEncodingTest.java
@@ -25,11 +25,12 @@ import java.util.Map;
 
 import org.junit.Test;
 import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.fs.jgit.util.commands.Commit;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
-public class JGitFileSystemProviderEncodingTest extends AbstractTestInfra {
+public class JGitFileSystemImplProviderEncodingTest extends AbstractTestInfra {
 
     private int gitDaemonPort;
 
@@ -45,12 +46,13 @@ public class JGitFileSystemProviderEncodingTest extends AbstractTestInfra {
         return gitPrefs;
     }
 
+
     @Test
     public void test() throws IOException {
         final URI originRepo = URI.create("git://encoding-origin-name");
 
         final JGitFileSystem origin = (JGitFileSystem) provider.newFileSystem(originRepo,
-                                                                              Collections.emptyMap());
+                                                                                      Collections.emptyMap());
 
         new Commit(origin.getGit(),
                    "master",
@@ -94,7 +96,7 @@ public class JGitFileSystemProviderEncodingTest extends AbstractTestInfra {
         final URI newRepo = URI.create("git://my-encoding-repo-name");
 
         final Map<String, Object> env = new HashMap<String, Object>() {{
-            put(JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME,
+            put(JGitFileSystemProviderConfiguration.GIT_ENV_KEY_DEFAULT_REMOTE_NAME,
                 "git://localhost:" + gitDaemonPort + "/encoding-origin-name");
         }};
 
@@ -107,7 +109,10 @@ public class JGitFileSystemProviderEncodingTest extends AbstractTestInfra {
 
         provider.getPath(fs.getPath("file+name.txt").toUri());
 
-        assertThat(provider.getPath(fs.getPath("file+name.txt").toUri())).isEqualTo(fs.getPath("file+name.txt"));
+        URI uri = fs.getPath("file+name.txt").toUri();
+        Path path = provider.getPath(uri);
+        Path path1 = fs.getPath("file+name.txt");
+        assertThat(path).isEqualTo(path1);
 
         assertThat(provider.getPath(fs.getPath("file name.txt").toUri())).isEqualTo(fs.getPath("file name.txt"));
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderGCTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderGCTest.java
@@ -28,7 +28,7 @@ import org.uberfire.java.nio.file.Path;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
 
-public class JGitFileSystemProviderGCTest extends AbstractTestInfra {
+public class JGitFileSystemImplProviderGCTest extends AbstractTestInfra {
 
     @Test
     public void testGC() throws IOException {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderHookTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderHookTest.java
@@ -39,7 +39,7 @@ import org.uberfire.java.nio.file.Path;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
-public class JGitFileSystemProviderHookTest extends AbstractTestInfra {
+public class JGitFileSystemImplProviderHookTest extends AbstractTestInfra {
 
     @Override
     public Map<String, String> getGitPreferences() {
@@ -75,8 +75,8 @@ public class JGitFileSystemProviderHookTest extends AbstractTestInfra {
 
         assertThat(fs).isNotNull();
 
-        if (fs instanceof JGitFileSystem) {
-            File[] hooks = new File(((JGitFileSystem) fs).getGit().getRepository().getDirectory(),
+        if (fs instanceof JGitFileSystemImpl) {
+            File[] hooks = new File(((JGitFileSystemImpl) fs).getGit().getRepository().getDirectory(),
                                     "hooks").listFiles();
             assertThat(hooks).isNotEmpty().isNotNull();
             assertThat(hooks.length).isEqualTo(2);

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderHttpProxyTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderHttpProxyTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import static java.net.Authenticator.requestPasswordAuthentication;
 import static org.junit.Assert.*;
 
-public class JGitFileSystemProviderHttpProxyTest {
+public class JGitFileSystemImplProviderHttpProxyTest {
 
     @Test
     public void testHttpProxy() throws MalformedURLException, UnknownHostException {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderMergeTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderMergeTest.java
@@ -33,7 +33,7 @@ import org.uberfire.java.nio.fs.jgit.util.exceptions.GitException;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
-public class JGitFileSystemProviderMergeTest extends AbstractTestInfra {
+public class JGitFileSystemImplProviderMergeTest extends AbstractTestInfra {
 
     @Test
     public void testMergeSuccessful() throws IOException, GitAPIException {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderMigrationTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderMigrationTest.java
@@ -21,16 +21,14 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.uberfire.java.nio.file.FileSystemNotFoundException;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Assertions.fail;
 
-/**
- * Created by aparedes on 9/16/16.
- */
-public class JGitFileSystemProviderMigrationTest extends AbstractTestInfra {
+public class JGitFileSystemImplProviderMigrationTest extends AbstractTestInfra {
 
     @Test
     public void testCreateANewDirectoryWithMigrationEnv() {
@@ -53,39 +51,4 @@ public class JGitFileSystemProviderMigrationTest extends AbstractTestInfra {
         assertThat(provider.getFileSystem(newUri)).isNotNull();
     }
 
-    @Test
-    public void testMigrateOldDirectories() {
-
-        final Map<String, ?> env = new HashMap<String, Object>() {{
-            put("init",
-                Boolean.TRUE);
-        }};
-
-        final Map<String, ?> envMigrate = new HashMap<String, Object>() {{
-            put("init",
-                Boolean.TRUE);
-            put("migrate-from",
-                URI.create("git://old"));
-        }};
-
-        String oldPath = "git://old";
-        final URI oldUri = URI.create(oldPath);
-        final JGitFileSystem fs = (JGitFileSystem) provider.newFileSystem(oldUri,
-                                                                          env);
-
-        String newPath = "git://test/old";
-        final URI newUri = URI.create(newPath);
-        provider.newFileSystem(newUri,
-                               envMigrate);
-
-        try {
-            provider.getFileSystem(oldUri);
-            fail("It should not reach here because old filesystem does not exists");
-        } catch (FileSystemNotFoundException ex) {
-            assertThat(new File(provider.getGitRepoContainerDir(),
-                                "test/old" + ".git").exists()).isTrue();
-            assertThat(new File(provider.getGitRepoContainerDir(),
-                                "old" + ".git").exists()).isFalse();
-        }
-    }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderSSHBadConfigTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderSSHBadConfigTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class JGitFileSystemProviderSSHBadConfigTest extends AbstractTestInfra {
+public class JGitFileSystemImplProviderSSHBadConfigTest extends AbstractTestInfra {
 
     @Override
     public Map<String, String> getGitPreferences() {
@@ -42,7 +42,7 @@ public class JGitFileSystemProviderSSHBadConfigTest extends AbstractTestInfra {
 
     @Test
     public void testCheckDefaultSSHIdleWithInvalidArg() throws IOException {
-        assertEquals(JGitFileSystemProvider.SSH_IDLE_TIMEOUT,
+        assertEquals(JGitFileSystemProviderConfiguration.DEFAULT_SSH_IDLE_TIMEOUT,
                      provider.getGitSSHService().getProperties().get(SshServer.IDLE_TIMEOUT));
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderSSHTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderSSHTest.java
@@ -35,7 +35,7 @@ import org.uberfire.java.nio.security.FileSystemUser;
 
 import static org.junit.Assert.*;
 
-public class JGitFileSystemProviderSSHTest extends AbstractTestInfra {
+public class JGitFileSystemImplProviderSSHTest extends AbstractTestInfra {
 
     private int gitSSHPort;
 
@@ -59,25 +59,13 @@ public class JGitFileSystemProviderSSHTest extends AbstractTestInfra {
         Assume.assumeFalse("UF-511",
                            System.getProperty("java.vendor").equals("IBM Corporation"));
         //Setup Authorization/Authentication
-        provider.setAuthenticator(new FileSystemAuthenticator() {
+        provider.setAuthenticator((username, password) -> new FileSystemUser() {
             @Override
-            public FileSystemUser authenticate(final String username,
-                                               final String password) {
-                return new FileSystemUser() {
-                    @Override
-                    public String getName() {
-                        return "admin";
-                    }
-                };
+            public String getName() {
+                return "admin";
             }
         });
-        provider.setAuthorizer(new FileSystemAuthorizer() {
-            @Override
-            public boolean authorize(final FileSystem fs,
-                                     final FileSystemUser fileSystemUser) {
-                return true;
-            }
-        });
+        provider.setAuthorizer((fs, fileSystemUser) -> true);
 
         CredentialsProvider.setDefault(new UsernamePasswordCredentialsProvider("admin",
                                                                                ""));

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderUnsupportedOpTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderUnsupportedOpTest.java
@@ -27,7 +27,7 @@ import org.uberfire.java.nio.file.Path;
 import static java.util.Collections.emptySet;
 import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
 
-public class JGitFileSystemProviderUnsupportedOpTest extends AbstractTestInfra {
+public class JGitFileSystemImplProviderUnsupportedOpTest extends AbstractTestInfra {
 
     @Test
     public void testNewFileSystemUnsupportedOp() {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderWithFoldersTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplProviderWithFoldersTest.java
@@ -34,7 +34,7 @@ import org.uberfire.java.nio.fs.jgit.util.GitImpl;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 
-public class JGitFileSystemProviderWithFoldersTest extends AbstractTestInfra {
+public class JGitFileSystemImplProviderWithFoldersTest extends AbstractTestInfra {
 
     @Test
     public void testNewFileSystemWithSubfolder() {
@@ -83,6 +83,12 @@ public class JGitFileSystemProviderWithFoldersTest extends AbstractTestInfra {
     @Test
     public void testExtractPathWithAuthority() {
 
+        provider.newFileSystem(URI.create("git://test/repo"),
+                               new HashMap<String, Object>() {{
+                                   put("init",
+                                       Boolean.TRUE);
+                               }});
+
         String path = "git://master@test/repo/readme.md";
         final URI uri = URI.create(path);
         final String extracted = provider.extractPath(uri);
@@ -92,6 +98,10 @@ public class JGitFileSystemProviderWithFoldersTest extends AbstractTestInfra {
     @Test
     public void testComplexExtractPath() {
 
+        final URI newRepo = URI.create("git://test/repo");
+        final FileSystem fs = provider.newFileSystem(newRepo,
+                                                     EMPTY_ENV);
+
         String path = "git://origin/master@test/repo/readme.md";
         final URI uri = URI.create(path);
         final String extracted = provider.extractPath(uri);
@@ -100,49 +110,31 @@ public class JGitFileSystemProviderWithFoldersTest extends AbstractTestInfra {
 
     @Test
     public void testExtractComplexRepoName() {
+        provider.newFileSystem(URI.create("default://test/repo"),
+                               new HashMap<String, Object>() {{
+                                   put("init",
+                                       Boolean.TRUE);
+                               }});
+
         String path = "git://origin/master@test/repo/readme.md";
         final URI uri = URI.create(path);
-        final String extracted = provider.extractRepoNameWithFolder(uri);
-        assertThat(extracted).isEqualTo("test/repo");
+        final String extracted = provider.extractFSNameWithPath(uri);
+        assertThat(extracted).isEqualTo("test/repo/readme.md");
     }
 
     @Test
     public void testExtractSimpleRepoName() {
         String path = "git://master@test/repo/readme.md";
         final URI uri = URI.create(path);
-        final String extracted = provider.extractRepoNameWithFolder(uri);
-        assertThat(extracted).isEqualTo("test/repo");
+        final String extracted = provider.extractFSNameWithPath(uri);
+        assertThat(extracted).isEqualTo("test/repo/readme.md");
     }
 
     @Test
     public void testExtractVerySimpleRepoName() {
         String path = "git://test/repo/readme.md";
         final URI uri = URI.create(path);
-        final String extracted = provider.extractRepoNameWithFolder(uri);
-        assertThat(extracted).isEqualTo("test/repo");
-    }
-
-    @Test
-    public void testExtractHostWithBranch() {
-        String path = "git://origin/master@test/repo/readme.md";
-        final URI uri = URI.create(path);
-        final String extracted = provider.extractHost(uri);
-        assertThat(extracted).isEqualTo("origin/master@test/repo");
-    }
-
-    @Test
-    public void testExtractHost() {
-        String path = "git://test/repo/readme.md";
-        final URI uri = URI.create(path);
-        final String extracted = provider.extractHost(uri);
-        assertThat(extracted).isEqualTo("test/repo");
-    }
-
-    @Test
-    public void testSimpleExtractHost() {
-        String path = "git://master@test/repo/readme.md";
-        final URI uri = URI.create(path);
-        final String extracted = provider.extractHost(uri);
-        assertThat(extracted).isEqualTo("master@test/repo");
+        final String extracted = provider.extractFSNameWithPath(uri);
+        assertThat(extracted).isEqualTo("test/repo/readme.md");
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemImplTest.java
@@ -32,7 +32,7 @@ import org.uberfire.java.nio.fs.jgit.util.GitImpl;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
-public class JGitFileSystemTest extends AbstractTestInfra {
+public class JGitFileSystemImplTest extends AbstractTestInfra {
 
     static {
         CredentialsProvider.setDefault(new UsernamePasswordCredentialsProvider("guest",
@@ -44,11 +44,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
         final JGitFileSystemProvider fsProvider = mock(JGitFileSystemProvider.class);
 
         final Git git = setupGit();
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
 
         assertThat(fileSystem.isReadOnly()).isFalse();
         assertThat(fileSystem.getSeparator()).isEqualTo("/");
@@ -68,11 +69,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
         final File tempDir = createTempDirectory();
         final Git git = new GitImpl(GitImpl._cloneRepository().setNoCheckout(false).setBare(true).setCloneAllBranches(true).setURI(setupGit().getRepository().getDirectory().toString()).setDirectory(tempDir).call());
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
 
         assertThat(fileSystem.isReadOnly()).isFalse();
         assertThat(fileSystem.getSeparator()).isEqualTo("/");
@@ -91,11 +93,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git = setupGit();
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
 
         assertThat(fileSystem.getName()).isEqualTo("my-repo");
         assertThat(fileSystem.isReadOnly()).isFalse();
@@ -110,11 +113,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git = setupGit();
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
 
         assertThat(fileSystem.isReadOnly()).isFalse();
         assertThat(fileSystem.getSeparator()).isEqualTo("/");
@@ -133,11 +137,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git = setupGit();
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
 
         assertThat(fileSystem.isReadOnly()).isFalse();
         assertThat(fileSystem.getSeparator()).isEqualTo("/");
@@ -155,11 +160,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git = setupGit();
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
 
         final Path path = fileSystem.getPath("/path/to/some/place.txt");
 
@@ -182,11 +188,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git = setupGit();
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
 
         final Path path = fileSystem.getPath("path/to/some/place.txt");
 
@@ -209,11 +216,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git = setupGit();
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
 
         final Path path = fileSystem.getPath("test-branch",
                                              "/path/to/some/place.txt");
@@ -237,11 +245,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git = setupGit();
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
 
         final Path path = fileSystem.getPath("test-branch",
                                              "path/to/some/place.txt");
@@ -265,11 +274,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git = setupGit();
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
 
         final Path path = fileSystem.getPath("test-branch",
                                              "/path/to",
@@ -294,11 +304,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git = setupGit();
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
 
         final Path path = fileSystem.getPath("test-branch",
                                              "path/to",
@@ -322,11 +333,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
         final File tempDir = createTempDirectory();
         final Git git = setupGit(tempDir);
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
 
         assertThat(fileSystem.getFileStores()).hasSize(1);
         final FileStore fileStore = fileSystem.getFileStores().iterator().next();
@@ -342,19 +354,21 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git1 = setupGit();
 
-        final JGitFileSystem fileSystem1 = new JGitFileSystem(fsProvider,
-                                                              null,
-                                                              git1,
-                                                              "my-repo1",
-                                                              CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem1 = new JGitFileSystemImpl(fsProvider,
+                                                                      null,
+                                                                      git1,
+                                                                      "my-repo1",
+                                                                      CredentialsProvider.getDefault(),
+                                                                      null);
 
         final Git git2 = setupGit();
 
-        final JGitFileSystem fileSystem2 = new JGitFileSystem(fsProvider,
-                                                              null,
-                                                              git2,
-                                                              "my-repo2",
-                                                              CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem2 = new JGitFileSystemImpl(fsProvider,
+                                                                      null,
+                                                                      git2,
+                                                                      "my-repo2",
+                                                                      CredentialsProvider.getDefault(),
+                                                                      null);
 
         final Path path1 = fileSystem1.getPath("master",
                                                "/path/to/some.txt");
@@ -373,11 +387,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git = setupGit();
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
         fileSystem.newWatchService();
     }
 
@@ -387,11 +402,12 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git = setupGit();
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
         fileSystem.getUserPrincipalLookupService();
     }
 
@@ -401,11 +417,55 @@ public class JGitFileSystemTest extends AbstractTestInfra {
 
         final Git git = setupGit();
 
-        final JGitFileSystem fileSystem = new JGitFileSystem(fsProvider,
-                                                             null,
-                                                             git,
-                                                             "my-repo",
-                                                             CredentialsProvider.getDefault());
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
         fileSystem.getPathMatcher("*");
+    }
+
+    @Test
+    public void lockShouldSupportMultiplieInnerLocksForTheSameThreadTest() throws IOException, GitAPIException {
+        final JGitFileSystemProvider fsProvider = mock(JGitFileSystemProvider.class);
+
+        final Git git = setupGit();
+
+        final JGitFileSystemImpl fileSystem = new JGitFileSystemImpl(fsProvider,
+                                                                     null,
+                                                                     git,
+                                                                     "my-repo",
+                                                                     CredentialsProvider.getDefault(),
+                                                                     null);
+
+        fileSystem.lock();
+        //inner locks
+        fileSystem.lock();
+        fileSystem.lock();
+        fileSystem.unlock();
+        fileSystem.unlock();
+        fileSystem.unlock();
+    }
+
+    @Test
+    public void lockTest() throws IOException, GitAPIException {
+
+        final Git git = setupGit();
+        JGitFileSystemImpl.Lock lock = new JGitFileSystemImpl.Lock(git.getRepository().getDirectory().toURI());
+
+        JGitFileSystemImpl.Lock lockSpy = spy(lock);
+
+        lockSpy.lock();
+        lockSpy.lock();
+        lockSpy.lock();
+        verify(lockSpy,
+               times(1)).physicalLockOnFS();
+
+        lockSpy.unlock();
+        lockSpy.unlock();
+        lockSpy.unlock();
+        verify(lockSpy,
+               times(1)).physicalUnLockOnFS();
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProxyTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProxyTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class JGitFileSystemProxyTest extends AbstractTestInfra {
+
+    private int gitDaemonPort;
+
+    @Override
+    public Map<String, String> getGitPreferences() {
+        Map<String, String> gitPrefs = super.getGitPreferences();
+        gitPrefs.put("org.uberfire.nio.git.daemon.enabled",
+                     "true");
+        // use different port for every test -> easy to run tests in parallel
+        gitDaemonPort = findFreePort();
+        gitPrefs.put("org.uberfire.nio.git.daemon.port",
+                     String.valueOf(gitDaemonPort));
+        return gitPrefs;
+    }
+
+    @Test
+    public void proxyTest() {
+        final URI originRepo = URI.create("git://encoding-origin-name");
+
+        final JGitFileSystem origin = (JGitFileSystem) provider.newFileSystem(originRepo,
+                                                                              Collections.emptyMap());
+
+        assertTrue(origin instanceof JGitFileSystemProxy);
+        JGitFileSystemProxy proxy = (JGitFileSystemProxy) origin;
+        JGitFileSystem realJGitFileSystem = proxy.getRealJGitFileSystem();
+        assertTrue(realJGitFileSystem instanceof JGitFileSystemImpl);
+
+        assertTrue(proxy.equals(realJGitFileSystem));
+        assertTrue(realJGitFileSystem.equals(proxy));
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitForkTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitForkTest.java
@@ -182,7 +182,7 @@ public class JGitForkTest extends AbstractTestInfra {
         String TARGET = "testforkB/target";
 
         final Map<String, ?> env = new HashMap<String, Object>() {{
-            put(JGitFileSystemProvider.GIT_ENV_KEY_INIT,
+            put(JGitFileSystemProviderConfiguration.GIT_ENV_KEY_INIT,
                 "true");
         }};
 
@@ -192,7 +192,7 @@ public class JGitForkTest extends AbstractTestInfra {
                                env);
 
         final Map<String, ?> forkEnv = new HashMap<String, Object>() {{
-            put(JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME,
+            put(JGitFileSystemProviderConfiguration.GIT_ENV_KEY_DEFAULT_REMOTE_NAME,
                 SOURCE);
         }};
         String forkPath = "git://" + TARGET;
@@ -212,7 +212,7 @@ public class JGitForkTest extends AbstractTestInfra {
         String TARGET = "testforkB/target";
 
         final Map<String, ?> env = new HashMap<String, Object>() {{
-            put(JGitFileSystemProvider.GIT_ENV_KEY_INIT,
+            put(JGitFileSystemProviderConfiguration.GIT_ENV_KEY_INIT,
                 "true");
         }};
 
@@ -222,7 +222,7 @@ public class JGitForkTest extends AbstractTestInfra {
                                env);
 
         final Map<String, ?> forkEnv = new HashMap<String, Object>() {{
-            put(JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME,
+            put(JGitFileSystemProviderConfiguration.GIT_ENV_KEY_DEFAULT_REMOTE_NAME,
                 SOURCE);
         }};
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/NewProviderDefineDirTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/NewProviderDefineDirTest.java
@@ -28,9 +28,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static org.fest.assertions.api.Assertions.assertThat;
-import static org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider.GIT_NIO_DIR;
-import static org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider.GIT_NIO_DIR_NAME;
-import static org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider.REPOSITORIES_CONTAINER_DIR;
+import static org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration.GIT_NIO_DIR;
+import static org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration.GIT_NIO_DIR_NAME;
+import static org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration.REPOSITORIES_CONTAINER_DIR;
 
 @RunWith(Parameterized.class)
 public class NewProviderDefineDirTest extends AbstractTestInfra {
@@ -68,15 +68,28 @@ public class NewProviderDefineDirTest extends AbstractTestInfra {
     public void testUsingProvidedPath() throws IOException {
         final URI newRepo = URI.create("git://repo-name");
 
-        provider.newFileSystem(newRepo,
-                               EMPTY_ENV);
+        JGitFileSystemProxy fileSystem = (JGitFileSystemProxy) provider.newFileSystem(newRepo,
+                                                                                      EMPTY_ENV);
 
-        final String[] names = tempDir.list();
+        //no infra created due to lazy loading nature of our FS
+        String[] names = tempDir.list();
+
+        assertThat(names).isEmpty();
+
+        String[] repos = new File(tempDir,
+                                  dirPathName).list();
+
+        assertThat(repos).isNull();
+
+        //FS created
+        fileSystem.getRealJGitFileSystem();
+
+        names = tempDir.list();
 
         assertThat(names).isNotEmpty().contains(dirPathName);
 
-        final String[] repos = new File(tempDir,
-                                        dirPathName).list();
+        repos = new File(tempDir,
+                         dirPathName).list();
 
         assertThat(repos).isNotEmpty().contains("repo-name.git");
     }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemsCacheTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemsCacheTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.jgit.manager;
+
+import java.util.function.Supplier;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystem;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProxy;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JGitFileSystemsCacheTest {
+
+    JGitFileSystemsCache cache;
+    private JGitFileSystemProviderConfiguration config;
+
+    @Before
+    public void setup() {
+        config = mock(JGitFileSystemProviderConfiguration.class);
+    }
+
+    @Test
+    public void addAndGetTest() {
+        when(config.getJgitFileSystemsInstancesCache()).thenReturn(2);
+        cache = new JGitFileSystemsCache(config);
+
+        assertTrue(cache.fileSystemsSuppliers.isEmpty());
+        assertTrue(cache.memoizedSuppliers.isEmpty());
+
+        assertEquals(null,
+                     cache.get("fs1"));
+
+        JGitFileSystem fs1 = mock(JGitFileSystem.class);
+        Supplier<JGitFileSystem> fs1Supplier = () -> fs1;
+        cache.addSupplier("fs1",
+                          fs1Supplier);
+
+        assertFalse(cache.fileSystemsSuppliers.isEmpty());
+        assertFalse(cache.memoizedSuppliers.isEmpty());
+
+        JGitFileSystemProxy fs1Proxy = (JGitFileSystemProxy) cache.get("fs1");
+
+        assertEquals(fs1,
+                     fs1Proxy.getRealJGitFileSystem());
+
+        assertTrue(cache.containsKey("fs1"));
+
+        cache.clear();
+
+        assertTrue(cache.fileSystemsSuppliers.isEmpty());
+        assertTrue(cache.memoizedSuppliers.isEmpty());
+    }
+
+    @Test
+    public void addMoreFSThanCacheSupports() {
+        when(config.getJgitFileSystemsInstancesCache()).thenReturn(2);
+        cache = new JGitFileSystemsCache(config);
+
+        JGitFileSystem fs1 = mock(JGitFileSystem.class);
+        Supplier<JGitFileSystem> fs1Supplier = getSupplierSpy(fs1);
+        cache.addSupplier("fs1",
+                          fs1Supplier);
+
+        assertEquals(1,
+                     cache.fileSystemsSuppliers.size());
+        assertEquals(1,
+                     cache.memoizedSuppliers.size());
+
+        ((JGitFileSystemProxy) cache.get("fs1")).getRealJGitFileSystem();
+
+        JGitFileSystem fs2 = mock(JGitFileSystem.class);
+        Supplier<JGitFileSystem> fs2Supplier = getSupplierSpy(fs2);
+        cache.addSupplier("fs2",
+                          fs2Supplier);
+        ((JGitFileSystemProxy) cache.get("fs2")).getRealJGitFileSystem();
+
+        assertEquals(2,
+                     cache.fileSystemsSuppliers.size());
+        assertEquals(2,
+                     cache.memoizedSuppliers.size());
+
+        JGitFileSystem fs3 = mock(JGitFileSystem.class);
+        Supplier<JGitFileSystem> fs3Supplier = getSupplierSpy(fs3);
+        cache.addSupplier("fs3",
+                          fs3Supplier);
+
+        ((JGitFileSystemProxy) cache.get("fs3")).getRealJGitFileSystem();
+
+        assertEquals(3,
+                     cache.fileSystemsSuppliers.size());
+        assertEquals(2,
+                     cache.memoizedSuppliers.size());
+
+        ((JGitFileSystemProxy) cache.get("fs2")).getRealJGitFileSystem();
+
+        //just one call because is on memoized cache
+        verify(fs2Supplier,
+               times(1)).get();
+
+        ((JGitFileSystemProxy) cache.get("fs3")).getRealJGitFileSystem();
+
+        //just one call because is on memoized cache
+        verify(fs3Supplier,
+               times(1)).get();
+
+        ((JGitFileSystemProxy) cache.get("fs1")).getRealJGitFileSystem();
+
+        // two calls because is on no longer on memoized cache (oldest instance) needs to regenerate
+        // from fs supplier
+        verify(fs1Supplier,
+               times(2)).get();
+    }
+
+    private Supplier<JGitFileSystem> getSupplierSpy(final JGitFileSystem fs1) {
+        return spy(new Supplier<JGitFileSystem>() {
+            @Override
+            public JGitFileSystem get() {
+                return fs1;
+            }
+        });
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemsManagerTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/manager/JGitFileSystemsManagerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit.manager;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystem;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProviderConfiguration;
+import org.uberfire.java.nio.fs.jgit.util.Git;
+import org.uberfire.java.nio.fs.jgit.ws.JGitFileSystemsEventsManager;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JGitFileSystemsManagerTest {
+
+    private JGitFileSystemProviderConfiguration config;
+
+    private JGitFileSystemsManager manager;
+
+    @Before
+    public void setup() {
+        config = mock(JGitFileSystemProviderConfiguration.class);
+    }
+
+    @Test
+    public void newFSTest() {
+        JGitFileSystem fs = mock(JGitFileSystem.class);
+        when(fs.getName()).thenReturn("fs");
+
+        JGitFileSystem fs1 = mock(JGitFileSystem.class);
+        when(fs1.getName()).thenReturn("fs1");
+
+        manager = new JGitFileSystemsManager(mock(JGitFileSystemProvider.class),
+                                             config);
+
+        manager.newFileSystem(() -> new HashMap<>(),
+                              () -> mock(Git.class),
+                              () -> fs.getName(),
+                              () -> mock(CredentialsProvider.class),
+                              () -> mock(JGitFileSystemsEventsManager.class));
+
+        manager.newFileSystem(() -> new HashMap<>(),
+                              () -> mock(Git.class),
+                              () -> fs1.getName(),
+                              () -> mock(CredentialsProvider.class),
+                              () -> mock(JGitFileSystemsEventsManager.class));
+
+        assertTrue(manager.containsKey("fs"));
+
+        manager.addClosedFileSystems(fs);
+
+        assertTrue(!manager.allTheFSAreClosed());
+
+        manager.clear();
+
+        assertTrue(manager.allTheFSAreClosed());
+    }
+
+    @Test
+    public void parseFSTest() {
+        manager = new JGitFileSystemsManager(mock(JGitFileSystemProvider.class),
+                                             config);
+
+        checkParse("a",
+                   Arrays.asList("a"));
+
+        checkParse("/a",
+                   Arrays.asList("a"));
+
+        checkParse("/a/",
+                   Arrays.asList("a"));
+
+        checkParse("a/b/",
+                   Arrays.asList("a",
+                                 "a/b"));
+
+        checkParse("/a/b/",
+                   Arrays.asList("a",
+                                 "a/b"));
+
+        checkParse("a/b/c",
+                   Arrays.asList("a",
+                                 "a/b",
+                                 "a/b/c"));
+
+        checkParse("a/b/c/d",
+                   Arrays.asList("a",
+                                 "a/b",
+                                 "a/b/c",
+                                 "a/b/c/d"));
+    }
+
+    private void checkParse(String fsKey,
+                            List<String> expected) {
+        List<String> actual = manager.parseFSRoots(fsKey);
+        assertEquals(actual.size(),
+                     expected.size());
+        for (String root : expected) {
+            if (!actual.contains(root)) {
+                throw new RuntimeException();
+            }
+        }
+        manager.clear();
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/manager/MemoizedFileSystemsSupplierTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/manager/MemoizedFileSystemsSupplierTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit.manager;
+
+import java.util.function.Supplier;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MemoizedFileSystemsSupplierTest {
+
+    public static int instanceCount = 0;
+
+    @Test
+    public void supplierTest() {
+
+        getSupplier().get();
+        getSupplier().get();
+        assertEquals(2,
+                     instanceCount);
+
+        instanceCount = 0;
+        final Supplier<DummyObject> supplier = getLazySupplier();
+        supplier.get();
+        supplier.get();
+        supplier.get();
+        supplier.get();
+        assertEquals(1,
+                     instanceCount);
+    }
+
+    Supplier<DummyObject> getLazySupplier() {
+        return MemoizedFileSystemsSupplier.of(getSupplier());
+    }
+
+    Supplier<DummyObject> getSupplier() {
+        return () -> new DummyObject();
+    }
+
+    private class DummyObject {
+
+        public DummyObject() {
+            test();
+            instanceCount++;
+        }
+
+        public void test() {
+            System.out.println("new Instance");
+        }
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/ws/JGitFileSystemsEventsManagerTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/ws/JGitFileSystemsEventsManagerTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.java.nio.fs.jgit.ws;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.file.WatchEvent;
+import org.uberfire.java.nio.file.WatchService;
+import org.uberfire.java.nio.fs.jgit.ws.cluster.ClusterParameters;
+import org.uberfire.java.nio.fs.jgit.ws.cluster.JGitEventsBroadcast;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JGitFileSystemsEventsManagerTest {
+
+    JGitFileSystemsEventsManager manager;
+    JGitEventsBroadcast jGitEventsBroadcastMock = mock(JGitEventsBroadcast.class);
+
+    @Before
+    public void setup() {
+        setupClusterParameters();
+        manager = new JGitFileSystemsEventsManager() {
+            @Override
+            void setupJGitEventsBroadcast() {
+                jGitEventsBroadcast = jGitEventsBroadcastMock;
+            }
+
+            @Override
+            JGitFileSystemWatchServices createFSWatchServicesManager() {
+                return mock(JGitFileSystemWatchServices.class);
+            }
+        };
+    }
+
+    @Test
+    public void doNotSetupClusterTest() {
+        JGitFileSystemsEventsManager another = new JGitFileSystemsEventsManager() {
+            @Override
+            ClusterParameters loadClusterParameters() {
+                return mock(ClusterParameters.class);
+            }
+        };
+        assertNull(another.getjGitEventsBroadcast());
+    }
+
+    @Test
+    public void setupClusterTest() {
+        assertNotNull(manager.getjGitEventsBroadcast());
+    }
+
+    @Test
+    public void createWatchService() {
+        manager = new JGitFileSystemsEventsManager() {
+            @Override
+            void setupJGitEventsBroadcast() {
+                jGitEventsBroadcast = jGitEventsBroadcastMock;
+            }
+        };
+
+        WatchService fs = manager.newWatchService("fs");
+
+        assertNotNull(fs);
+        assertTrue(manager.getFsWatchServices().containsKey("fs"));
+        verify(jGitEventsBroadcastMock).createWatchServiceJMS("fs");
+    }
+
+    @Test
+    public void shouldNotPublishEventsForANotWatchedFS() {
+        WatchService fsDora = manager.newWatchService("fsDora");
+        WatchService fsBento = manager.newWatchService("fsBento");
+
+        List<WatchEvent<?>> elist = Arrays.asList(mock(WatchEvent.class),
+                                                  mock(WatchEvent.class));
+
+        manager.publishEvents("another",
+                              mock(Path.class),
+                              elist);
+
+        verify(jGitEventsBroadcastMock,
+               never()).broadcast(any(),
+                                  any(),
+                                  any());
+    }
+
+    @Test
+    public void publishEventsShouldBeWatched() {
+        WatchService fsDoraWS = manager.newWatchService("fsDora");
+        WatchService fsBento = manager.newWatchService("fsBento");
+
+        JGitFileSystemWatchServices fsDoraWServices = manager.getFsWatchServices().get("fsDora");
+        JGitFileSystemWatchServices fsBentoWServices = manager.getFsWatchServices().get("fsBento");
+
+        List<WatchEvent<?>> elist = Arrays.asList(mock(WatchEvent.class),
+                                                  mock(WatchEvent.class));
+
+        manager.publishEvents("fsDora",
+                              mock(Path.class),
+                              elist);
+
+        verify(fsDoraWServices).publishEvents(any(),
+                                              eq(elist));
+        verify(jGitEventsBroadcastMock).broadcast(eq("fsDora"),
+                                                  any(),
+                                                  eq(elist));
+        verify(fsBentoWServices,
+               never()).publishEvents(any(),
+                                      eq(elist));
+    }
+
+    @Test
+    public void publishEventsWithoutBroadcast() {
+        manager.newWatchService("fsDora");
+        manager.newWatchService("fsBento");
+
+        JGitFileSystemWatchServices fsDoraWServices = manager.getFsWatchServices().get("fsDora");
+        JGitFileSystemWatchServices fsBentoWServices = manager.getFsWatchServices().get("fsBento");
+
+        List<WatchEvent<?>> elist = Arrays.asList(mock(WatchEvent.class),
+                                                  mock(WatchEvent.class));
+
+        manager.publishEvents("fsDora",
+                              mock(Path.class),
+                              elist,
+                              false);
+
+        verify(fsDoraWServices).publishEvents(any(),
+                                              eq(elist));
+        verify(jGitEventsBroadcastMock,
+               never()).broadcast(eq("fsDora"),
+                                  any(),
+                                  eq(elist));
+        verify(fsBentoWServices,
+               never()).publishEvents(any(),
+                                      eq(elist));
+    }
+
+    @Test
+    public void watchServicesEvents() {
+
+        manager = new JGitFileSystemsEventsManager() {
+            @Override
+            void setupJGitEventsBroadcast() {
+                jGitEventsBroadcast = jGitEventsBroadcastMock;
+            }
+        };
+
+        WatchService fsDora1 = manager.newWatchService("fsDora");
+        WatchService fsDora2 = manager.newWatchService("fsDora");
+
+        List<WatchEvent<?>> list3events = Arrays.asList(mock(WatchEvent.class),
+                                                        mock(WatchEvent.class),
+                                                        mock(WatchEvent.class));
+
+        List<WatchEvent<?>> list2events = Arrays.asList(mock(WatchEvent.class),
+                                                        mock(WatchEvent.class));
+
+        manager.publishEvents("fsDora",
+                              mock(Path.class),
+                              list3events,
+                              false);
+
+        List<WatchEvent<?>> watchEvents = fsDora1.poll().pollEvents();
+        assertEquals(3,
+                     watchEvents.size());
+        watchEvents = fsDora2.poll().pollEvents();
+        assertEquals(3,
+                     watchEvents.size());
+
+        manager.publishEvents("fsDora",
+                              mock(Path.class),
+                              list3events,
+                              false);
+        manager.publishEvents("fsDora",
+                              mock(Path.class),
+                              list2events,
+                              false);
+
+        watchEvents = fsDora2.poll().pollEvents();
+        assertEquals(3,
+                     watchEvents.size());
+
+        watchEvents = fsDora2.poll().pollEvents();
+        assertEquals(2,
+                     watchEvents.size());
+
+        watchEvents = fsDora1.poll().pollEvents();
+        assertEquals(3,
+                     watchEvents.size());
+
+        watchEvents = fsDora1.poll().pollEvents();
+        assertEquals(2,
+                     watchEvents.size());
+    }
+
+    @Test
+    public void closeTest() {
+        manager.newWatchService("fsDora");
+        manager.newWatchService("fsBento");
+
+        JGitFileSystemWatchServices fsDoraWServices = manager.getFsWatchServices().get("fsDora");
+        JGitFileSystemWatchServices fsBentoWServices = manager.getFsWatchServices().get("fsBento");
+
+        manager.close("fsDora");
+
+        verify(fsDoraWServices).close();
+        verify(fsBentoWServices,
+               never()).close();
+    }
+
+    private void setupClusterParameters() {
+        System.setProperty(ClusterParameters.APPFORMER_CLUSTER,
+                           "true");
+        System.setProperty(ClusterParameters.APPFORMER_DEFAULT_CLUSTER_CONFIGS,
+                           "true");
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/resources/byteman/retry/get_commits.btm
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/resources/byteman/retry/get_commits.btm
@@ -16,7 +16,7 @@ RULE catch counter testRetryGetCommits
 CLASS org.eclipse.jgit.revwalk.RevWalk
 METHOD markStart(org.eclipse.jgit.revwalk.RevCommit)
 AT EXIT
-IF readCounter("testRetryGetCommits") > 7
+IF readCounter("testRetryGetCommits") > 3
 DO
    throw RuntimeException("almost random failure");
 ENDRULE

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/resources/byteman/retry/get_last_commit.btm
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/resources/byteman/retry/get_last_commit.btm
@@ -16,7 +16,7 @@ RULE catch counter testRetryGetLastCommit
 CLASS org.eclipse.jgit.revwalk.RevCommit
 METHOD parse(byte[])
 AT EXIT
-IF readCounter("testRetryGetLastCommit") > 7 #each commit executes the RevCommit.parse too
+IF readCounter("testRetryGetLastCommit") >  8 #each commit executes the RevCommit.parse too
 DO
    throw RuntimeException("almost random failure");
 ENDRULE

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/AmbiguousFileSystemNameException.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/AmbiguousFileSystemNameException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.file;
+
+public class AmbiguousFileSystemNameException extends RuntimeException {
+
+    public AmbiguousFileSystemNameException() {
+    }
+
+    public AmbiguousFileSystemNameException(String msg) {
+        super(msg);
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/FileSystem.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/FileSystem.java
@@ -49,4 +49,6 @@ public interface FileSystem extends Closeable,
     UserPrincipalLookupService getUserPrincipalLookupService() throws UnsupportedOperationException;
 
     WatchService newWatchService() throws UnsupportedOperationException, IOException;
+
+    String getName();
 }

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/FileSystemMetadata.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/FileSystemMetadata.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.file;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+import org.uberfire.java.nio.base.FileSystemId;
+
+public class FileSystemMetadata {
+
+    private String scheme;
+    private final String uri;
+    private boolean isAFileSystemID;
+    private String id;
+
+    public FileSystemMetadata(FileSystem fs) {
+        if (fs.getRootDirectories().iterator().hasNext()) {
+            Path root = fs.getRootDirectories().iterator().next();
+            final FileSystem realFS = root.getFileSystem();
+
+            isAFileSystemID = fs instanceof FileSystemId;
+            if (isAFileSystemID) {
+                id = ((FileSystemId) realFS).id();
+            } else {
+                id = fs.toString();
+            }
+            this.scheme = root.toUri().getScheme();
+        }
+        this.uri = fs.toString();
+    }
+
+    public boolean isAFileSystemID() {
+        return isAFileSystemID;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getScheme() {
+        return scheme;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FileSystemMetadata that = (FileSystemMetadata) o;
+
+        if (isAFileSystemID != that.isAFileSystemID) {
+            return false;
+        }
+        if (scheme != null ? !scheme.equals(that.scheme) : that.scheme != null) {
+            return false;
+        }
+        if (uri != null ? !uri.equals(that.uri) : that.uri != null) {
+            return false;
+        }
+        return id != null ? id.equals(that.id) : that.id == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = scheme != null ? scheme.hashCode() : 0;
+        result = 31 * result + (uri != null ? uri.hashCode() : 0);
+        result = 31 * result + (isAFileSystemID ? 1 : 0);
+        result = 31 * result + (id != null ? id.hashCode() : 0);
+        return result;
+    }
+
+    public void closeFS() throws IOException {
+        java.nio.file.Path path = Paths.get(uri);
+        java.nio.file.FileSystem fileSystem = path.getFileSystem();
+        fileSystem.close();
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/LockableFileSystem.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/LockableFileSystem.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.file;
+
+public interface LockableFileSystem {
+
+    void lock();
+
+    void unlock();
+}

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/WatchEvent.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/WatchEvent.java
@@ -16,7 +16,9 @@
 
 package org.uberfire.java.nio.file;
 
-public interface WatchEvent<T> {
+import java.io.Serializable;
+
+public interface WatchEvent<T> extends Serializable {
 
     Kind<T> kind();
 

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/WatchKey.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/file/WatchKey.java
@@ -16,9 +16,10 @@
 
 package org.uberfire.java.nio.file;
 
+import java.io.Serializable;
 import java.util.List;
 
-public interface WatchKey {
+public interface WatchKey extends Serializable {
 
     boolean isValid();
 

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/security/FileSystemUser.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/security/FileSystemUser.java
@@ -16,9 +16,6 @@
 
 package org.uberfire.java.nio.security;
 
-/**
- * TODO: update me
- */
 public interface FileSystemUser {
 
     String getName();

--- a/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/POMServiceImpl.java
+++ b/uberfire-project/uberfire-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/POMServiceImpl.java
@@ -35,7 +35,6 @@ import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.io.IOService;
 import org.uberfire.java.nio.file.FileAlreadyExistsException;
-import org.uberfire.java.nio.file.FileSystem;
 
 @Service
 @WorkspaceScoped
@@ -136,7 +135,7 @@ public class POMServiceImpl
 
         try {
 
-            ioService.startBatch(new FileSystem[]{Paths.convert(path).getFileSystem()},
+            ioService.startBatch(Paths.convert(path).getFileSystem(),
                                  optionsFactory.makeCommentedOption(comment != null ? comment : ""));
 
             save(path,

--- a/uberfire-services/uberfire-services-backend/src/test/java/org/guvnor/common/services/backend/MockIOService.java
+++ b/uberfire-services/uberfire-services-backend/src/test/java/org/guvnor/common/services/backend/MockIOService.java
@@ -37,6 +37,7 @@ import org.uberfire.java.nio.file.DirectoryStream;
 import org.uberfire.java.nio.file.FileAlreadyExistsException;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.java.nio.file.FileSystemAlreadyExistsException;
+import org.uberfire.java.nio.file.FileSystemMetadata;
 import org.uberfire.java.nio.file.FileSystemNotFoundException;
 import org.uberfire.java.nio.file.InterruptedException;
 import org.uberfire.java.nio.file.NoSuchFileException;
@@ -71,19 +72,8 @@ public class MockIOService
     }
 
     @Override
-    public void startBatch(FileSystem[] fileSystems,
-                           Option... options) throws InterruptedException {
-
-    }
-
-    @Override
     public void startBatch(FileSystem fileSystem,
                            Option... options) throws InterruptedException {
-
-    }
-
-    @Override
-    public void startBatch(FileSystem... fileSystems) throws InterruptedException {
 
     }
 
@@ -109,7 +99,7 @@ public class MockIOService
     }
 
     @Override
-    public Iterable<FileSystem> getFileSystems() {
+    public Iterable<FileSystemMetadata> getFileSystemMetadata() {
         return null;
     }
 

--- a/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/backend/server/impl/AppSetup.java
+++ b/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/backend/server/impl/AppSetup.java
@@ -49,7 +49,6 @@ public class AppSetup {
                                             PLAYGROUND_UID);
                                     }});
         } catch (final FileSystemAlreadyExistsException ignore) {
-
         }
     }
 }

--- a/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/client/ShowcaseEntryPoint.java
+++ b/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/client/ShowcaseEntryPoint.java
@@ -15,7 +15,13 @@
  */
 package org.uberfire.client;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
@@ -267,14 +273,7 @@ public class ShowcaseEntryPoint {
         //Sort Perspective Providers so they're always in the same sequence!
         List<PerspectiveActivity> sortedActivities = new ArrayList<>(activities);
         Collections.sort(sortedActivities,
-                         new Comparator<PerspectiveActivity>() {
-
-                             @Override
-                             public int compare(PerspectiveActivity o1,
-                                                PerspectiveActivity o2) {
-                                 return o1.getName().compareTo(o2.getName());
-                             }
-                         });
+                         (o1, o2) -> o1.getName().compareTo(o2.getName()));
 
         return sortedActivities;
     }
@@ -306,14 +305,11 @@ public class ShowcaseEntryPoint {
     @Produces
     @ApplicationScoped
     public MainBrand createBrandLogo() {
-        return new MainBrand() {
-            @Override
-            public Widget asWidget() {
-                final Image image = new Image(AppResource.INSTANCE.images().ufBrandLogo());
-                image.getElement().setAttribute("height",
-                                                "10");
-                return image;
-            }
+        return () -> {
+            final Image image = new Image(AppResource.INSTANCE.images().ufBrandLogo());
+            image.getElement().setAttribute("height",
+                                            "10");
+            return image;
         };
     }
 

--- a/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/git/GitMetadataStoreImpl.java
+++ b/uberfire-structure/uberfire-structure-backend/src/main/java/org/guvnor/structure/backend/repositories/git/GitMetadataStoreImpl.java
@@ -33,7 +33,7 @@ public class GitMetadataStoreImpl implements GitMetadataStore {
 
     private Logger logger = LoggerFactory.getLogger(GitMetadataStoreImpl.class);
     public static final String SEPARATOR = "/";
-    public static final String METADATA = "default://system/metadata";
+    public static final String METADATA = "default://system_ou/metadata";
 
     private ObjectStorage storage;
 

--- a/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/repositories/git/GitMetadataImplStoreTest.java
+++ b/uberfire-structure/uberfire-structure-backend/src/test/java/org/guvnor/structure/backend/repositories/git/GitMetadataImplStoreTest.java
@@ -74,7 +74,7 @@ public class GitMetadataImplStoreTest {
     @Test
     public void testStorageInitialization() {
         metadataStore.init();
-        verify(storage).init(eq("default://system/metadata"));
+        verify(storage).init(eq("default://system_ou/metadata"));
     }
 
     @Test


### PR DESCRIPTION
#[BPMSPL-744] GIT related enhancements for scalable workspaces
-------------------------------------------------------------------

First commit: [link](https://github.com/AppFormer/uberfire/pull/881/commits/2373c1cd5d5659dffbea8355901185c036ce79dd) 
JGITFS support for multiple and scalable FS
(prerequisite for workspaces and cloud, all the FS are as lazy as possible)
Also:
[AF-573] Refactoring in order to centralize FileSystem Calls
[AF-569] Cleanup and simplify clustering

Second commit: [link](https://github.com/AppFormer/uberfire/pull/881/commits/98feb1edfba45be0751491f9c0700d05b940e507)
[AF-584] FS New Cloud Watch Service: new watch clustered/cloud watch service using jms (artemis activemq)
[AF-569] Simplify clustering (removal of zookeper and helix need in appformer cluster - still pending the code cleanup)

Wars to play around:
---------------------
Kie-wb war: https://www.dropbox.com/s/wd74z7781wjpf7d/kie-wb-7.5.0-SNAPSHOT-eap7.war?dl=0

To run the new cluster infra:
----------------------------
Please, someone, validate this :)

1. Download [artemis 2.3.0](https://activemq.apache.org/artemis/download.html) and unzip it;

2. Create your broker: apache-artemis-2.3.0/bin/artemis create mybroker

3. Enter bin of your broker and run mybroker/bin/./artemis run
@paulovmr get some issues with busy ports, if this is your case, create your broker on step 2 with --port-offset=1000

4. Deploy some of the wars in standalone

5. Run jboss first node:
./standalone.sh -c standalone-full.xml -Dorg.uberfire.nio.git.dir=/tmp/testewildfly -Dappformer-cluster=true -Dappformer-jms-url=tcp://localhost:61616 -Dappformer-jms-username=admin -Dappformer-jms-password=admin

6. Create a new fresh copy of your wildfly and change the standalone full configs in order to prevent shared ports:
 
```...
  </extensions>...
<system-properties>
       <property name=“org.uberfire.nio.git.daemon.port” value=“9420"/>
       <property name=“org.uberfire.nio.git.ssh.port” value=“8004"/>
   </system-properties>
```

7. Run second node

./standalone.sh -c standalone-full.xml -Dorg.uberfire.nio.git.dir=/tmp/testewildfly -Djboss.socket.binding.port-offset=1000 -Dappformer-cluster=true -Dappformer-jms-url=tcp://localhost:61616 -Dappformer-jms-username=admin -Dappformer-jms-password=admin

8. Load both web apps (one in incognito mode to prevent errai bus clash), open the same asset in both

9. Start to type and you will see the lock in the asset. If you see it, it works ;)

 
Depends on [ 
-------------
https://github.com/errai/errai/pull/297

Child PRs
----------
https://github.com/kiegroup/guvnor/pull/530
https://github.com/kiegroup/kie-wb-common/pull/1257
https://github.com/kiegroup/jbpm-designer/pull/686
https://github.com/kiegroup/jbpm-wb/pull/925

Related PRs (not a dependency)
------------------------------
https://github.com/apache/activemq-artemis/pull/1606 (merged)

Still pending:
-------------
- Remove old cluster infra
- Fix Social to new cluster infra