### PR TITLE
Pom cleanup

### DIFF
--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-api/pom.xml
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-api/pom.xml
@@ -58,12 +58,6 @@
       <artifactId>uberfire-nio2-model</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-common</artifactId>
-    </dependency>
-
-
   </dependencies>
 
 </project>

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/pom.xml
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/pom.xml
@@ -107,11 +107,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-backend-cdi</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-maven-integration</artifactId>
       <exclusions>

--- a/uberfire-project/uberfire-project-backend/pom.xml
+++ b/uberfire-project/uberfire-project-backend/pom.xml
@@ -106,10 +106,6 @@
       <artifactId>uberfire-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-io</artifactId>
     </dependency>

--- a/uberfire-rest/uberfire-rest-backend/pom.xml
+++ b/uberfire-rest/uberfire-rest-backend/pom.xml
@@ -120,6 +120,7 @@
       <plugin>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
+        <version>0.8.1</version>
       </plugin>
     </plugins>
   </build>

--- a/uberfire-structure/uberfire-structure-backend/pom.xml
+++ b/uberfire-structure/uberfire-structure-backend/pom.xml
@@ -120,10 +120,6 @@
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.kie.soup</groupId>
-      <artifactId>kie-soup-commons</artifactId>
-    </dependency>
 
     <!-- Weld Modules. For tests only -->
     <dependency>


### PR DESCRIPTION
Fixing: 

[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.uberfire:uberfire-m2repo-editor-api:jar:2.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.jboss.errai:errai-common:jar -> duplicate declaration of version (?) @ org.uberfire:uberfire-m2repo-editor-api:[unknown-version], /Users/ederign/projects/forks/uberfire/uberfire-m2repo-editor/uberfire-m2repo-editor-api/pom.xml, line 61, column 17
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.uberfire:uberfire-m2repo-editor-backend:jar:2.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.uberfire:uberfire-backend-cdi:jar -> duplicate declaration of version (?) @ org.uberfire:uberfire-m2repo-editor-backend:[unknown-version], /Users/ederign/projects/forks/uberfire/uberfire-m2repo-editor/uberfire-m2repo-editor-backend/pom.xml, line 109, column 17
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.uberfire:uberfire-project-backend:jar:2.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.kie.soup:kie-soup-commons:jar -> duplicate declaration of version (?) @ org.uberfire:uberfire-project-backend:[unknown-version], /Users/ederign/projects/forks/uberfire/uberfire-project/uberfire-project-backend/pom.xml, line 108, column 17
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.uberfire:uberfire-rest-backend:jar:2.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.revapi:revapi-maven-plugin is missing. @ org.uberfire:uberfire-rest-backend:[unknown-version], /Users/ederign/projects/forks/uberfire/uberfire-rest/uberfire-rest-backend/pom.xml, line 120, column 15
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.uberfire:uberfire-structure-backend:jar:2.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.kie.soup:kie-soup-commons:jar -> duplicate declaration of version (?) @ org.uberfire:uberfire-structure-backend:[unknown-version], /Users/ederign/projects/forks/uberfire/uberfire-structure/uberfire-structure-backend/pom.xml, line 123, column 17
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]