### PR TITLE
RHBRMS-3022: Cannot disable "Delete" button for Analyst role in business central

### DIFF
--- a/uberfire-api/src/main/java/org/uberfire/workbench/model/menu/MenuFactory.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/model/menu/MenuFactory.java
@@ -127,6 +127,8 @@ public final class MenuFactory {
         T withRoles( final String... roles );
 
         T withRoles( final Collection<String> roles );
+
+        T withNamespace( final String namespace );
     }
 
     public interface CustomMenuBuilder {

--- a/uberfire-api/src/main/java/org/uberfire/workbench/model/menu/impl/MenuBuilderImpl.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/model/menu/impl/MenuBuilderImpl.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
+import com.google.common.base.Joiner;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
@@ -63,7 +64,7 @@ public final class MenuBuilderImpl
     final Stack<MenuFactory.CustomMenuBuilder> context = new Stack<MenuFactory.CustomMenuBuilder>();
     int order = 0;
 
-    private static class CurrentContext implements MenuFactory.CustomMenuBuilder {
+    static class CurrentContext implements MenuFactory.CustomMenuBuilder {
 
         MenuItem menu = null;
 
@@ -73,6 +74,7 @@ public final class MenuBuilderImpl
         Set<String> roles = new HashSet<String>();
         MenuPosition position = MenuPosition.LEFT;
         String contributionPoint = null;
+        String namespace = null;
         Command command = null;
         PlaceRequest placeRequest = null;
         List<MenuItem> menuItems = new ArrayList<MenuItem>();
@@ -141,11 +143,10 @@ public final class MenuBuilderImpl
 
                     @Override
                     public String getSignatureId() {
-                        if ( contributionPoint != null ) {
-                            return getClass().getName() + "#" + contributionPoint + "#" + caption;
 
-                        }
-                        return getClass().getName() + "#" + caption;
+                        final String[] signatureParts = { getClass().getName(), contributionPoint, namespace, caption };
+
+                        return Joiner.on( '#' ).skipNulls().join( signatureParts );
                     }
 
                     @Override
@@ -223,11 +224,10 @@ public final class MenuBuilderImpl
 
                     @Override
                     public String getSignatureId() {
-                        if ( contributionPoint != null ) {
-                            return getClass().getName() + "#" + contributionPoint + "#" + caption;
 
-                        }
-                        return getClass().getName() + "#" + caption;
+                        final String[] signatureParts = { getClass().getName(), contributionPoint, namespace, caption };
+
+                        return Joiner.on( '#' ).skipNulls().join( signatureParts );
                     }
 
                     @Override
@@ -300,11 +300,10 @@ public final class MenuBuilderImpl
 
                     @Override
                     public String getSignatureId() {
-                        if ( contributionPoint != null ) {
-                            return getClass().getName() + "#" + contributionPoint + "#" + caption;
 
-                        }
-                        return getClass().getName() + "#" + caption;
+                        final String[] signatureParts = { getClass().getName(), contributionPoint, namespace, caption };
+
+                        return Joiner.on( '#' ).skipNulls().join( signatureParts );
                     }
 
                     @Override
@@ -372,11 +371,10 @@ public final class MenuBuilderImpl
 
                 @Override
                 public String getSignatureId() {
-                    if ( contributionPoint != null ) {
-                        return getClass().getName() + "#" + contributionPoint + "#" + caption;
 
-                    }
-                    return getClass().getName() + "#" + caption;
+                    final String[] signatureParts = { getClass().getName(), contributionPoint, namespace, caption };
+
+                    return Joiner.on( '#' ).skipNulls().join( signatureParts );
                 }
 
                 @Override
@@ -541,6 +539,12 @@ public final class MenuBuilderImpl
             ( (CurrentContext) context.peek() ).roles.add( role );
         }
 
+        return this;
+    }
+
+    @Override
+    public MenuBuilderImpl withNamespace(final String namespace) {
+        ( (CurrentContext) context.peek() ).namespace = checkNotEmpty( "namespace", namespace );
         return this;
     }
 

--- a/uberfire-api/src/test/java/org/uberfire/workbench/model/menu/MenuFactoryTest.java
+++ b/uberfire-api/src/test/java/org/uberfire/workbench/model/menu/MenuFactoryTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.workbench.model.menu;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MenuFactoryTest {
+
+    @Test
+    public void testMenuFactorySecurityInfosNamespace() {
+
+        final String caption = "caption";
+        final String namespace = "namespace";
+
+        final Menus build = MenuFactory
+                .newSimpleItem( caption )
+                .withNamespace( namespace )
+                .endMenu()
+                .build();
+
+        final MenuItem menuItem = build.getItems().get( 0 );
+        final String expectedSignature = "org.uberfire.workbench.model.menu.impl.MenuBuilderImpl$CurrentContext$4#namespace#caption";
+        final String actualSignature = menuItem.getSignatureId();
+
+        assertEquals( expectedSignature, actualSignature );
+    }
+}

--- a/uberfire-api/src/test/java/org/uberfire/workbench/model/menu/impl/MenuBuilderImplTest.java
+++ b/uberfire-api/src/test/java/org/uberfire/workbench/model/menu/impl/MenuBuilderImplTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.workbench.model.menu.impl;
+
+import org.junit.Test;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.model.menu.MenuGroup;
+import org.uberfire.workbench.model.menu.MenuItem;
+import org.uberfire.workbench.model.menu.MenuItemCommand;
+import org.uberfire.workbench.model.menu.MenuItemPerspective;
+import org.uberfire.workbench.model.menu.MenuItemPlain;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class MenuBuilderImplTest {
+
+    @Test
+    public void testMenuGroupGetSignatureId() {
+
+        final MenuBuilderImpl.CurrentContext context = new MenuBuilderImpl.CurrentContext() {{
+
+            contributionPoint = "contributionPoint";
+
+            namespace = "namespace";
+
+            caption = "caption";
+
+            menuItems.add( mock( MenuItem.class ) );
+        }};
+
+        final MenuItem build = context.build();
+
+        assertTrue( build instanceof MenuGroup );
+
+        final String expectedSignature = "org.uberfire.workbench.model.menu.impl.MenuBuilderImpl$CurrentContext$1#contributionPoint#namespace#caption";
+        final String actualSignature = build.getSignatureId();
+
+        assertEquals( expectedSignature, actualSignature );
+    }
+
+    @Test
+    public void testMenuItemCommandGetSignatureId() {
+
+        final MenuBuilderImpl.CurrentContext context = new MenuBuilderImpl.CurrentContext() {{
+
+            contributionPoint = "contributionPoint";
+
+            namespace = "namespace";
+
+            caption = "caption";
+
+            command = command();
+        }};
+
+        final MenuItem build = context.build();
+
+        assertTrue( build instanceof MenuItemCommand );
+
+        final String expectedSignature = "org.uberfire.workbench.model.menu.impl.MenuBuilderImpl$CurrentContext$2#contributionPoint#namespace#caption";
+        final String actualSignature = build.getSignatureId();
+
+        assertEquals( expectedSignature, actualSignature );
+    }
+
+    @Test
+    public void testMenuItemPerspectiveGetSignatureId() {
+
+        final MenuBuilderImpl.CurrentContext context = new MenuBuilderImpl.CurrentContext() {{
+
+            contributionPoint = "contributionPoint";
+
+            namespace = "namespace";
+
+            caption = "caption";
+
+            placeRequest = mock( PlaceRequest.class );
+        }};
+
+        final MenuItem build = context.build();
+
+        assertTrue( build instanceof MenuItemPerspective );
+
+        final String expectedSignature = "org.uberfire.workbench.model.menu.impl.MenuBuilderImpl$CurrentContext$3#contributionPoint#namespace#caption";
+        final String actualSignature = build.getSignatureId();
+
+        assertEquals( expectedSignature, actualSignature );
+    }
+
+    @Test
+    public void testMenuItemPlainGetSignatureId() {
+
+        final MenuBuilderImpl.CurrentContext context = new MenuBuilderImpl.CurrentContext() {{
+
+            contributionPoint = "contributionPoint";
+
+            namespace = "namespace";
+
+            caption = "caption";
+        }};
+
+        final MenuItem build = context.build();
+
+        assertTrue( build instanceof MenuItemPlain );
+
+        final String expectedSignature = "org.uberfire.workbench.model.menu.impl.MenuBuilderImpl$CurrentContext$4#contributionPoint#namespace#caption";
+        final String actualSignature = build.getSignatureId();
+
+        assertEquals( expectedSignature, actualSignature );
+    }
+
+    private Command command() {
+        return new Command() {
+            public void execute() {
+                // empty
+            }
+        };
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-3022

Before:
![before](https://user-images.githubusercontent.com/1079279/32587825-d0201672-c4f1-11e7-9d41-34a258a5e3d5.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/32587824-cd99e338-c4f1-11e7-9db2-cf0f28e49eac.gif)

---

Menus from other editors were interfering with permissions to enable/disable delete (and other buttons) in the Project Editor.

---

Part of an ensemble:
- https://github.com/AppFormer/uberfire/pull/903
- https://github.com/kiegroup/kie-wb-common/pull/1284

