### PR TITLE
AF-650: Upload without choosing file causes exception in Artifact repository

### DIFF
--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/upload/UploadFormPresenter.java
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/upload/UploadFormPresenter.java
@@ -24,7 +24,6 @@ import org.guvnor.m2repo.client.event.M2RepoSearchEvent;
 import org.gwtbootstrap3.client.shared.event.ModalHideEvent;
 import org.gwtbootstrap3.client.shared.event.ModalHideHandler;
 import org.gwtbootstrap3.client.ui.base.form.AbstractForm;
-import org.gwtbootstrap3.client.ui.gwt.FormPanel;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 
 import static org.guvnor.m2repo.model.HTMLFileManagerFields.UPLOAD_MISSING_POM;
@@ -80,21 +79,18 @@ public class UploadFormPresenter implements UploadFormView.Presenter {
         }
     }
 
-    /*
-     * After upgrade of GWT-BOOTSTRAP3 version, will be needed to handle
-     * org.gwtbootstrap3.client.ui.Form.SubmitEvent
-     */
     @Override
-    public void handleSubmit(final FormPanel.SubmitEvent event) {
+    public boolean isFileNameValid() {
         String fileName = view.getFileName();
         if (fileName == null || "".equals(fileName)) {
             view.showSelectFileUploadWarning();
-            event.cancel();
+            return false;
         } else if (!(isValid(fileName))) {
             view.showUnsupportedFileTypeWarning();
-            event.cancel();
+            return false;
         } else {
             view.showUploadingBusy();
+            return true;
         }
     }
 

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/upload/UploadFormView.java
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/upload/UploadFormView.java
@@ -19,7 +19,6 @@ import com.google.web.bindery.event.shared.HandlerRegistration;
 import org.guvnor.m2repo.client.upload.UploadFormView.Presenter;
 import org.gwtbootstrap3.client.shared.event.ModalHideHandler;
 import org.gwtbootstrap3.client.ui.base.form.AbstractForm;
-import org.gwtbootstrap3.client.ui.gwt.FormPanel;
 import org.uberfire.client.mvp.UberView;
 
 public interface UploadFormView extends UberView<Presenter> {
@@ -28,11 +27,7 @@ public interface UploadFormView extends UberView<Presenter> {
 
         void handleSubmitComplete(AbstractForm.SubmitCompleteEvent event);
 
-        /*
-         * After upgrade of GWT-BOOTSTRAP3 version, will be needed to handle
-         * org.gwtbootstrap3.client.ui.Form.SubmitEvent
-         */
-        void handleSubmit(FormPanel.SubmitEvent event);
+        boolean isFileNameValid();
     }
 
     String getFileName();

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/upload/UploadFormViewImpl.java
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/upload/UploadFormViewImpl.java
@@ -34,7 +34,6 @@ import org.uberfire.ext.widgets.common.client.common.FormStyleItem;
 import org.uberfire.ext.widgets.common.client.common.FormStyleLayout;
 import org.uberfire.ext.widgets.common.client.common.popups.BaseModal;
 import org.uberfire.ext.widgets.common.client.common.popups.errors.ErrorPopup;
-import org.uberfire.mvp.Command;
 
 public class UploadFormViewImpl
         extends BaseModal implements UploadFormView {
@@ -73,27 +72,14 @@ public class UploadFormViewImpl
         form.setMethod(FormPanel.METHOD_POST);
         form.setType(FormType.HORIZONTAL);
 
-        /*
-         * After upgrade of GWT-BOOTSTRAP3 version, will be needed to register
-         * org.gwtbootstrap3.client.ui.Form.SubmitHandler
-         */
-        form.addHandler(new FormPanel.SubmitHandler() {
-                            @Override
-                            public void onSubmit(com.google.gwt.user.client.ui.FormPanel.SubmitEvent submitEvent) {
-                                presenter.handleSubmit(submitEvent);
-                            }
-                        },
-                        FormPanel.SubmitEvent.getType());
-
         form.addSubmitCompleteHandler(new Form.SubmitCompleteHandler() {
             public void onSubmitComplete(final Form.SubmitCompleteEvent event) {
                 presenter.handleSubmitComplete(event);
             }
         });
 
-        uploader = new FileUpload(new Command() {
-            @Override
-            public void execute() {
+        uploader = new FileUpload(() -> {
+            if (presenter.isFileNameValid()) {
                 form.submit();
             }
         });

--- a/uberfire-m2repo-editor/uberfire-m2repo-editor-client/src/test/java/org/guvnor/m2repo/client/upload/UploadFormTest.java
+++ b/uberfire-m2repo-editor/uberfire-m2repo-editor-client/src/test/java/org/guvnor/m2repo/client/upload/UploadFormTest.java
@@ -22,7 +22,6 @@ import org.guvnor.m2repo.client.event.M2RepoSearchEvent;
 import org.gwtbootstrap3.client.shared.event.ModalHideEvent;
 import org.gwtbootstrap3.client.shared.event.ModalHideHandler;
 import org.gwtbootstrap3.client.ui.base.form.AbstractForm;
-import org.gwtbootstrap3.client.ui.gwt.FormPanel;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -72,7 +71,7 @@ public class UploadFormTest {
     @Test
     public void emptyFilenameTest() {
         when(view.getFileName()).thenReturn(null);
-        uploadFormPresenter.handleSubmit(new FormPanel.SubmitEvent());
+        uploadFormPresenter.isFileNameValid();
 
         verify(view).showSelectFileUploadWarning();
         verify(view,
@@ -82,7 +81,7 @@ public class UploadFormTest {
     @Test
     public void nullFilenameTest() {
         when(view.getFileName()).thenReturn("");
-        uploadFormPresenter.handleSubmit(new FormPanel.SubmitEvent());
+        uploadFormPresenter.isFileNameValid();
 
         verify(view).showSelectFileUploadWarning();
         verify(view,
@@ -92,7 +91,7 @@ public class UploadFormTest {
     @Test
     public void unsupportedFilenameTest() {
         when(view.getFileName()).thenReturn("//!#@%^&*()\\23\\(0");
-        uploadFormPresenter.handleSubmit(new FormPanel.SubmitEvent());
+        uploadFormPresenter.isFileNameValid();
 
         verify(view).showUnsupportedFileTypeWarning();
         verify(view,
@@ -102,7 +101,7 @@ public class UploadFormTest {
     @Test
     public void correctFilenameTest() {
         when(view.getFileName()).thenReturn("/home/user/something/pom.xml");
-        uploadFormPresenter.handleSubmit(new FormPanel.SubmitEvent());
+        uploadFormPresenter.isFileNameValid();
 
         verify(view).showUploadingBusy();
     }


### PR DESCRIPTION
Method handleSubmit(SubmitEvent event) was never called due to a bug in gwt-bootstrap3, see https://github.com/gwtbootstrap3/gwtbootstrap3/issues/375. The fix is a workaround that enables the validation of the file name before submitting the form. 
@karreiro Could you, please, take a look at this fix? 