### PR TITLE
Remove useless System.out.println

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/JGitWatchEvent.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/ws/JGitWatchEvent.java
@@ -47,12 +47,6 @@ public class JGitWatchEvent implements WatchEvent {
         this.userName = userName;
         this.message = message;
         this.changeType = changeType;
-        if (oldPath != null) {
-            System.out.println(oldPath.toUri().toString());
-        }
-        if (newPath != null) {
-            System.out.println(newPath.toUri().toString());
-        }
         this.oldPath = oldPath != null ? oldPath.toUri() : null;
         this.newPath = newPath != null ? newPath.toUri() : null;
     }


### PR DESCRIPTION
@ederign please check. This System.out.println causes bunch of useless logs being printed in appserver console every time user does something with project assets. 


<details> <summary>like this</summary>
<pre>
7:17:26,516 INFO  [stdout] (default task-126) default://master@preferences/config/user/testadmin/LibraryInternalPreferences.preferences
07:22:54,736 INFO  [stdout] (default task-29) default://master@myrepo/abc/.global
07:22:54,736 INFO  [stdout] (default task-29) default://master@myrepo/abc/global/.gitkeep
07:22:54,737 INFO  [stdout] (default task-29) default://master@myrepo/abc/global/customeditors.json
07:22:54,737 INFO  [stdout] (default task-29) default://master@myrepo/abc/global/defaultemailicon.gif
07:22:54,737 INFO  [stdout] (default task-29) default://master@myrepo/abc/global/defaultlogicon.gif
07:22:54,738 INFO  [stdout] (default task-29) default://master@myrepo/abc/global/defaultmilestoneicon.png
07:22:54,739 INFO  [stdout] (default task-29) default://master@myrepo/abc/global/defaultservicenodeicon.png
07:22:54,739 INFO  [stdout] (default task-29) default://master@myrepo/abc/global/defaultsubcaseicon.png
07:22:54,740 INFO  [stdout] (default task-29) default://master@myrepo/abc/global/patterns.json
07:22:54,742 INFO  [stdout] (default task-29) default://master@myrepo/abc/global/themes.json
07:22:54,743 INFO  [stdout] (default task-29) default://master@myrepo/abc/package-names-white-list
07:22:54,745 INFO  [stdout] (default task-29) default://master@myrepo/abc/pom.xml
07:22:54,746 INFO  [stdout] (default task-29) default://master@myrepo/abc/project.imports
07:22:54,746 INFO  [stdout] (default task-29) default://master@myrepo/abc/project.repositories
07:22:54,747 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/main/.java
07:22:54,748 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/main/.resources
07:22:54,749 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/main/java/.gitkeep
07:22:54,751 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/main/java/com/myteam/.abc
07:22:54,752 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/main/java/com/myteam/abc/.gitkeep
07:22:54,753 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/main/resources/.gitkeep
07:22:54,754 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/main/resources/META-INF/kmodule.xml
07:22:54,755 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/main/resources/com/myteam/.abc
07:22:54,756 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/main/resources/com/myteam/abc/.gitkeep
07:22:54,757 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/test/.java
07:22:54,757 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/test/.resources
07:22:54,758 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/test/java/.gitkeep
07:22:54,761 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/test/java/com/myteam/.abc
07:22:54,762 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/test/java/com/myteam/abc/.gitkeep
07:22:54,763 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/test/resources/.gitkeep
07:22:54,763 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/test/resources/com/myteam/.abc
07:22:54,765 INFO  [stdout] (default task-29) default://master@myrepo/abc/src/test/resources/com/myteam/abc/.gitkeep
07:22:55,123 INFO  [org.guvnor.common.services.builder.ResourceChangeIncrementalBuilder] (Thread-160) Batch incremental build request received.
07:23:02,512 INFO  [stdout] (default task-43) default://master@myrepo/asdf/.global
07:23:02,513 INFO  [stdout] (default task-43) default://master@myrepo/asdf/global/.gitkeep
07:23:02,513 INFO  [stdout] (default task-43) default://master@myrepo/asdf/global/customeditors.json
07:23:02,513 INFO  [stdout] (default task-43) default://master@myrepo/asdf/global/defaultemailicon.gif
07:23:02,514 INFO  [stdout] (default task-43) default://master@myrepo/asdf/global/defaultlogicon.gif
07:23:02,514 INFO  [stdout] (default task-43) default://master@myrepo/asdf/global/defaultmilestoneicon.png
07:23:02,514 INFO  [stdout] (default task-43) default://master@myrepo/asdf/global/defaultservicenodeicon.png
07:23:02,515 INFO  [stdout] (default task-43) default://master@myrepo/asdf/global/defaultsubcaseicon.png
07:23:02,515 INFO  [stdout] (default task-43) default://master@myrepo/asdf/global/patterns.json
07:23:02,515 INFO  [stdout] (default task-43) default://master@myrepo/asdf/global/themes.json
07:23:02,516 INFO  [stdout] (default task-43) default://master@myrepo/asdf/package-names-white-list
07:23:02,516 INFO  [stdout] (default task-43) default://master@myrepo/asdf/pom.xml
07:23:02,516 INFO  [stdout] (default task-43) default://master@myrepo/asdf/project.imports
07:23:02,517 INFO  [stdout] (default task-43) default://master@myrepo/asdf/project.repositories
07:23:02,517 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/main/.java
07:23:02,518 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/main/.resources
07:23:02,518 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/main/java/.gitkeep
07:23:02,518 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/main/java/com/myteam/.asdf
07:23:02,519 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/main/java/com/myteam/asdf/.gitkeep
07:23:02,519 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/main/resources/.gitkeep
07:23:02,520 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/main/resources/META-INF/kmodule.xml
07:23:02,520 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/main/resources/com/myteam/.asdf
07:23:02,520 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/main/resources/com/myteam/asdf/.gitkeep
07:23:02,521 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/test/.java
07:23:02,522 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/test/.resources
07:23:02,522 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/test/java/.gitkeep
07:23:02,523 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/test/java/com/myteam/.asdf
07:23:02,523 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/test/java/com/myteam/asdf/.gitkeep
07:23:02,523 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/test/resources/.gitkeep
07:23:02,524 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/test/resources/com/myteam/.asdf
07:23:02,524 INFO  [stdout] (default task-43) default://master@myrepo/asdf/src/test/resources/com/myteam/asdf/.gitkeep
</pre>
</details>

If you think these logs are useful (I don't think they are) then we should replace them by logging instead.